### PR TITLE
Import CTI BSP for r32.1 (version v125)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ $(foreach overlay,$(KERNEL_OVERLAYS),$(eval $(value set_srctree_overlay)))
 VERSION = 4
 PATCHLEVEL = 9
 SUBLEVEL = 140
-EXTRAVERSION =
+EXTRAVERSION = -tegra
 NAME = Roaring Lionus
 
 # *DOCUMENTATION*

--- a/drivers/gpio/gpio-pca953x.c
+++ b/drivers/gpio/gpio-pca953x.c
@@ -997,7 +997,10 @@ static int __init pca953x_init(void)
 /* register after i2c postcore initcall and before
  * subsys initcalls that may rely on these GPIOs
  */
-subsys_initcall(pca953x_init);
+//subsys_initcall(pca953x_init);
+fs_initcall_sync(pca953x_init);
+
+
 
 static void __exit pca953x_exit(void)
 {

--- a/drivers/pci/host/pci-tegra.c
+++ b/drivers/pci/host/pci-tegra.c
@@ -4710,16 +4710,17 @@ static void pcie_delayed_detect(struct work_struct *work)
 	ret = tegra_pcie_probe_complete(pcie);
 	if (ret || !pcie->num_ports) {
 		pm_runtime_put_sync(pcie->dev);
-		goto release_regulators;
+		//goto release_regulators;
 	}
 	return;
 
-release_regulators:
+/*release_regulators:
 	devm_kfree(pcie->dev, pcie->pcie_regulators);
 	devm_kfree(pcie->dev, pcie->plat_data);
 	pci_free_host_bridge(pcie->host);
 	platform_set_drvdata(pdev, NULL);
-	return;
+	return;*/
+
 }
 
 #ifdef CONFIG_THERMAL
@@ -5209,6 +5210,7 @@ static void __exit tegra_pcie_exit_driver(void)
 	platform_driver_unregister(&tegra_pcie_driver);
 }
 
-module_init(tegra_pcie_init_driver);
+fs_initcall(tegra_pcie_init_driver);
+//module_init(tegra_pcie_init_driver);
 module_exit(tegra_pcie_exit_driver);
 MODULE_LICENSE("GPL v2");

--- a/make_clean.sh
+++ b/make_clean.sh
@@ -1,0 +1,26 @@
+#
+#   Script to clean all previously built resources. 
+#   Clobbers output kernel and driver modules, targets tegra21_defconfig
+#   afterwards for next build.
+#
+
+#!/bin/bash
+if [ -z "$TEGRA_KERNEL_OUT" ]
+then
+
+echo "TEGRA_KERNEL_OUT is not set, source the setup_crosdev.sh"
+
+else
+echo "cleaning"
+
+make O=$TEGRA_KERNEL_OUT clean
+rm -r $TEGRA_KERNEL_OUT/*
+rm -r $L4T_ROOT_DIR/built_modules/*
+rm $L4T_ROOT_DIR/Linux_for_Tegra/kernel/dtb/*
+#rm -r $TEGRA_KERNEL_OUT/.config
+make mrproper
+make O=$TEGRA_KERNEL_OUT mrproper
+#make O=$TEGRA_KERNEL_OUT tegra_cti_defconfig 
+make ARCH=arm64 O=$TEGRA_KERNEL_OUT tegra_defconfig 
+
+fi

--- a/make_script.sh
+++ b/make_script.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+if [ -z "$TEGRA_KERNEL_OUT" ]
+then
+
+echo "TEGRA_KERNEL_OUT is not set, source the setup_crosdev.sh"
+
+else
+
+
+make O=$TEGRA_KERNEL_OUT -j8 zImage
+make O=$TEGRA_KERNEL_OUT -j4 dtbs
+make O=$TEGRA_KERNEL_OUT -j4 modules
+make O=$TEGRA_KERNEL_OUT -j4 modules_install INSTALL_MOD_PATH=$L4T_ROOT_DIR/built_modules
+echo done
+
+fi
+

--- a/nvidia/drivers/media/i2c/imx185.c
+++ b/nvidia/drivers/media/i2c/imx185.c
@@ -632,6 +632,8 @@ static int imx185_set_mode(struct tegracam_device *tc_dev)
 static int imx185_start_streaming(struct tegracam_device *tc_dev)
 {
 	struct imx185 *priv = (struct imx185 *)tegracam_get_privdata(tc_dev);
+	struct camera_common_data *s_data = tc_dev->s_data;
+	struct device *dev = tc_dev->dev;
 	int err;
 
 	if (test_mode) {
@@ -640,6 +642,13 @@ static int imx185_start_streaming(struct tegracam_device *tc_dev)
 		if (err)
 			return err;
 	}
+	
+    if(s_data->numlanes == 2){
+        dev_dbg(dev,"%s: Setting to 2 CSI Lanes\n",__func__);
+        err = imx185_write_table(priv, mode_table[IMX185_MODE_2_LANE]);
+        if (err)
+            return err;
+    }
 
 	err = imx185_write_table(priv,
 		mode_table[IMX185_MODE_START_STREAM]);

--- a/nvidia/drivers/media/i2c/imx185_mode_tbls.h
+++ b/nvidia/drivers/media/i2c/imx185_mode_tbls.h
@@ -961,6 +961,21 @@ static imx185_reg imx185_1920x1080_crop_10bit_30fps[] = {
 	{IMX185_TABLE_END, 0x00}
 };
 
+static imx185_reg imx185_2_lane_conf[] = {
+    {0x3303, 0x00},
+    {0x3305, 0x01},
+    {0x332c, 0x40},
+    {0x3340, 0x01},
+    {0x3343, 0x68},
+    {0x3344, 0x20},
+    {0x3345, 0x40},
+    {0x3346, 0x28},
+    {0x3347, 0x20},
+    {0x3348, 0x18},
+    {0x3349, 0x78},
+    {IMX185_TABLE_END, 0x00}
+};
+
 enum {
 	IMX185_MODE_1920X1080_CROP_30FPS,
 	IMX185_MODE_1920X1080_CROP_10BIT_30FPS,
@@ -969,6 +984,7 @@ enum {
 	IMX185_MODE_1920X1080_CROP_HDR_30FPS,
 	IMX185_MODE_START_STREAM,
 	IMX185_MODE_STOP_STREAM,
+	IMX185_MODE_2_LANE,	
 	IMX185_MODE_TEST_PATTERN
 };
 
@@ -983,6 +999,7 @@ static imx185_reg *mode_table[] = {
 		imx185_1920x1080_hdr_crop_30fps,
 	[IMX185_MODE_START_STREAM] = imx185_start,
 	[IMX185_MODE_STOP_STREAM] = imx185_stop,
+	[IMX185_MODE_2_LANE] = imx185_2_lane_conf,
 	[IMX185_MODE_TEST_PATTERN] = tp_colorbars,
 };
 

--- a/nvidia/drivers/media/i2c/imx274_mode_tbls.h
+++ b/nvidia/drivers/media/i2c/imx274_mode_tbls.h
@@ -154,7 +154,7 @@ static const imx274_reg mode_3840X2160[] = {
 };
 
 /* Mode 1 : 3840X2160 10 bits 60fps*/
-static const imx274_reg mode_3840X2160_60fps[] = {
+static const imx274_reg mode_3840X2160_60fps_4lane[] = {
 	{IMX274_TABLE_WAIT_MS, IMX274_WAIT_MS},
 	{0x3000, 0x12}, /* mode select streaming on */
 	/* input freq. 24M */
@@ -198,6 +198,106 @@ static const imx274_reg mode_3840X2160_60fps[] = {
 	{0x30E2, 0x01},
 	{0x30F6, 0x07},
 	{0x30F7, 0x01},
+//	{0x30F6, 0x0e}, // HMAX , 263
+//	{0x30F7, 0x02}, // HMAX
+	{0x30F8, 0xC6},
+	{0x30F9, 0x11},
+	{0x3130, 0x78}, /*WRITE_VSIZE*/
+	{0x3131, 0x08},
+	{0x3132, 0x70}, /*Y_OUT_SIZE*/
+	{0x3133, 0x08},
+
+	/* crop */
+	{0x30DD, 0x01}, /*VWIDCUTEN*/
+	{0x30DE, 0x04}, /*VWIDCUT*/
+	{0x30E0, 0x03}, /*VWINCUTPOS*/
+	{0x3037, 0x01}, /*HTRIMMING_EN*/
+	{0x3038, 0x0C}, /*HTRIMMING_START*/
+	{0x3039, 0x00},
+	{0x303A, 0x0C}, /*HTRIMMING_END*/
+	{0x303B, 0x0F},
+
+	/* mode setting */
+	{0x3004, 0x01},
+	{0x3005, 0x01},
+	{0x3006, 0x00},
+	{0x3007, 0x02},
+	{0x300C, 0x0C}, /* SHR: Minimum 12 */
+	{0x300D, 0x00},
+	{0x300E, 0x00},
+	{0x3019, 0x00},
+	{0x3A41, 0x08},
+	{0x3342, 0x0A},
+	{0x3343, 0x00},
+	{0x3344, 0x16},
+	{0x3345, 0x00},
+	{0x3528, 0x0E},
+	{0x3554, 0x1F},
+	{0x3555, 0x01},
+	{0x3556, 0x01},
+	{0x3557, 0x01},
+	{0x3558, 0x01},
+	{0x3559, 0x00},
+	{0x355A, 0x00},
+	{0x35BA, 0x0E},
+	{0x366A, 0x1B},
+	{0x366B, 0x1A},
+	{0x366C, 0x19},
+	{0x366D, 0x17},
+	{0x33A6, 0x01},
+	{0x306B, 0x05},
+
+	{IMX274_TABLE_WAIT_MS, IMX274_WAIT_MS},
+	{IMX274_TABLE_END, 0x0000}
+};
+
+/* Mode 1 : 3840X2160 10 bits 60fps*/
+static const imx274_reg mode_3840X2160_60fps_2lane[] = {
+	{IMX274_TABLE_WAIT_MS, IMX274_WAIT_MS},
+	{0x3000, 0x12}, /* mode select streaming on */
+	/* input freq. 24M */
+	{0x3120, 0xF0},
+	{0x3122, 0x02},
+	{0x3129, 0x9c},
+	{0x312A, 0x02},
+	{0x312D, 0x02},
+
+	{0x310B, 0x00},
+	{0x304C, 0x00},
+	{0x304D, 0x03},
+	{0x331C, 0x1A},
+	{0x3502, 0x02},
+	{0x3529, 0x0E},
+	{0x352A, 0x0E},
+	{0x352B, 0x0E},
+	{0x3538, 0x0E},
+	{0x3539, 0x0E},
+	{0x3553, 0x00},
+	{0x357D, 0x05},
+	{0x357F, 0x05},
+	{0x3581, 0x04},
+	{0x3583, 0x76},
+	{0x3587, 0x01},
+	{0x35BB, 0x0E},
+	{0x35BC, 0x0E},
+	{0x35BD, 0x0E},
+	{0x35BE, 0x0E},
+	{0x35BF, 0x0E},
+	{0x366E, 0x00},
+	{0x366F, 0x00},
+	{0x3670, 0x00},
+	{0x3671, 0x00},
+	{0x30EE, 0x01},
+	{0x3304, 0x32},
+	{0x3306, 0x32},
+	{0x3590, 0x32},
+	{0x3686, 0x32},
+	/* resolution */
+	{0x30E2, 0x01},
+//	{0x30F6, 0x07},
+//	{0x30F7, 0x01},
+	{0x30F6, 0x0e}, // HMAX , 263
+	{0x30F7, 0x02}, // HMAX
 	{0x30F8, 0xC6},
 	{0x30F9, 0x11},
 	{0x3130, 0x78}, /*WRITE_VSIZE*/
@@ -664,6 +764,12 @@ static const imx274_reg mode_1288x546[] = {
 	{IMX274_TABLE_END, 0x0000}
 };
 
+static const imx274_reg imx274_2_lane_conf[] = {
+    {0x312E, 0x01},
+    {0x3AA2, 0x01},
+    {IMX274_TABLE_END, 0x00}
+};
+
 enum {
 	IMX274_MODE_3840X2160,
 	IMX274_MODE_1920X1080,
@@ -673,10 +779,11 @@ enum {
 	IMX274_MODE_START_STREAM,
 	IMX274_MODE_STOP_STREAM,
 	IMX274_MODE_TEST_PATTERN,
+	IMX274_MODE_2_LANE,
 };
 
 static const imx274_reg *mode_table[] = {
-	[IMX274_MODE_3840X2160] = mode_3840X2160_60fps,
+	[IMX274_MODE_3840X2160] = mode_3840X2160_60fps_2lane,
 	[IMX274_MODE_1920X1080] = mode_1920X1080,
 	[IMX274_MODE_3840X2160_DOL_30FPS] = mode_3840X2160_dol_30fps,
 	[IMX274_MODE_1920X1080_DOL_60FPS] = mode_1920X1080_dol_60fps,
@@ -684,6 +791,19 @@ static const imx274_reg *mode_table[] = {
 	[IMX274_MODE_START_STREAM]		= imx274_start,
 	[IMX274_MODE_STOP_STREAM]		= imx274_stop,
 	[IMX274_MODE_TEST_PATTERN]		= tp_colorbars,
+	[IMX274_MODE_2_LANE] = imx274_2_lane_conf,
+};
+
+static const imx274_reg *mode_table_4lane[] = {
+	[IMX274_MODE_3840X2160] = mode_3840X2160_60fps_4lane,
+	[IMX274_MODE_1920X1080] = mode_1920X1080,
+	[IMX274_MODE_3840X2160_DOL_30FPS] = mode_3840X2160_dol_30fps,
+	[IMX274_MODE_1920X1080_DOL_60FPS] = mode_1920X1080_dol_60fps,
+	[IMX274_MODE_1288X546] = mode_1288x546,
+	[IMX274_MODE_START_STREAM]		= imx274_start,
+	[IMX274_MODE_STOP_STREAM]		= imx274_stop,
+	[IMX274_MODE_TEST_PATTERN]		= tp_colorbars,
+	[IMX274_MODE_2_LANE] = imx274_2_lane_conf,
 };
 
 static const int imx274_30_fr[] = {

--- a/nvidia/drivers/video/tegra/dc/edid.c
+++ b/nvidia/drivers/video/tegra/dc/edid.c
@@ -610,11 +610,21 @@ int tegra_edid_get_ex_hdr_cap_info(struct tegra_edid *edid,
 
 inline bool tegra_edid_is_rgb_quantization_selectable(struct tegra_edid *edid)
 {
+
+	if (!edid || !edid->data) {
+		pr_warn("edid invalid\n");
+		return 0;
+	}
 	return edid->data->rgb_quant_selectable;
 }
 
 inline bool tegra_edid_is_yuv_quantization_selectable(struct tegra_edid *edid)
 {
+
+	if (!edid || !edid->data) {
+		pr_warn("edid invalid\n");
+		return 0;
+	}
 	return edid->data->yuv_quant_selectable;
 }
 

--- a/nvidia/platform/t18x/common/kernel-dts/t18x-common-platforms/tegra186-tx2-cti-camera-base.dtsi
+++ b/nvidia/platform/t18x/common/kernel-dts/t18x-common-platforms/tegra186-tx2-cti-camera-base.dtsi
@@ -1,0 +1,384 @@
+
+/*Base include for cameras, sets up all the CSI and VI lanes etc,
+include this file in any baord specific camera files */
+
+
+#define CAM0_RST_L  TEGRA_MAIN_GPIO(R, 5)
+#define CAM0_PWDN   TEGRA_MAIN_GPIO(R, 0)
+//#define CAM1_RST_L    TEGRA_MAIN_GPIO(R, 1)
+//#define CAM1_PWDN TEGRA_MAIN_GPIO(L, 6)
+
+/ {
+    tegra-camera-platform {
+        /**
+        * tpg_max_iso = <>;
+        * Max iso bw for 6 streams of tpg
+        * streams * nvcsi_freq * PG_bitrate / RG10 * BPP
+        * 6 * 102Mhz * 32 bits/ 10 bits * 2 Bps
+        * = 3916.8 MBps
+        */
+        tpg_max_iso = <3916800>;
+    };
+
+    /* set camera gpio direction to output */
+/*  gpio@2200000 {
+        camera-control-output-low {
+            gpio-hog;
+            output-low;
+            gpios = <CAM0_RST_L 0 CAM0_PWDN 0
+                 CAM1_RST_L 0 CAM1_PWDN 0>;
+            label = "cam0-rst", "cam0-pwdn",
+                "cam1-rst", "cam1-pwdn";
+        };
+    };*/
+
+    /* all cameras are disabled by default */
+    host1x {
+        vi_base: vi@15700000 {
+            num-channels = <6>;
+            ports {
+                #address-cells = <1>;
+                #size-cells = <0>;
+                vi_port0: port@0 {
+                    reg = <0>;
+                    status = "disabled";
+                    vi_in0: endpoint {
+                        status = "disabled";
+                    };
+                };
+                vi_port1: port@1 {
+                    reg = <1>;
+                    status = "disabled";
+                    vi_in1: endpoint {
+                        status = "disabled";
+                    };
+                };
+                vi_port2: port@2 {
+                    reg = <2>;
+                    status = "disabled";
+                    vi_in2: endpoint {
+                        status = "disabled";
+                    };
+                };
+                vi_port3: port@3 {
+                    reg = <3>;
+                    status = "disabled";
+                    vi_in3: endpoint {
+                        status = "disabled";
+                    };
+                };
+                vi_port4: port@4 {
+                    reg = <4>;
+                    status = "disabled";
+                    vi_in4: endpoint {
+                        status = "disabled";
+                    };
+                };
+                vi_port5: port@5 {
+                    reg = <5>;
+                    status = "disabled";
+                    vi_in5: endpoint {
+                        status = "disabled";
+                    };
+                };
+            };
+        };
+        csi_base: nvcsi@150c0000 {
+            #address-cells = <1>;
+            #size-cells = <0>;
+            num-channels = <6>;
+            status = "okay";
+            csi_chan0: channel@0 {
+                status = "disabled";
+                reg = <0>;
+                ports {
+                    #address-cells = <1>;
+                    #size-cells = <0>;
+                    csi_chan0_port0: port@0 {
+                        status = "disabled";
+                        reg = <0>;
+                        csi_in0: endpoint@0 {
+                            status = "disabled";
+
+                        };
+                    };
+                    csi_chan0_port1: port@1 {
+                        status = "disabled";
+                        reg = <1>;
+                        csi_out0: endpoint@1 {
+                            status = "disabled";
+                        };
+                    };
+                };
+            };
+            csi_chan1: channel@1 {
+                reg = <1>;
+                status = "disabled";
+                ports {
+                    #address-cells = <1>;
+                    #size-cells = <0>;
+                    csi_chan1_port0: port@0 {
+                        status = "disabled";
+                        reg = <0>;
+                        csi_in1: endpoint@2 {
+                            status = "disabled";
+                        };
+                    };
+                    csi_chan1_port1: port@1 {
+                        status = "disabled";
+                        reg = <1>;
+                        csi_out1: endpoint@3 {
+                            status = "disabled";
+                        };
+                    };
+                };
+            };
+            csi_chan2: channel@2 {
+                reg = <2>;
+                status = "disabled";
+                ports {
+                    #address-cells = <1>;
+                    #size-cells = <0>;
+                    csi_chan2_port0: port@0 {
+                        status = "disabled";
+                        reg = <0>;
+                        csi_in2: endpoint@4 {
+                            status = "disabled";
+                        };
+                    };
+                    csi_chan2_port1: port@1 {
+                        status = "disabled";
+                        reg = <1>;
+                        csi_out2: endpoint@5 {
+                            status = "disabled";
+                        };
+                    };
+                };
+            };
+            csi_chan3: channel@3 {
+                reg = <3>;
+                status = "disabled";
+                ports {
+                    #address-cells = <1>;
+                    #size-cells = <0>;
+                    csi_chan3_port0: port@0 {
+                        status = "disabled";
+                        reg = <0>;
+                        csi_in3: endpoint@6 {
+                            status = "disabled";
+                        };
+                    };
+                    csi_chan3_port1: port@1 {
+                        status = "disabled";
+                        reg = <1>;
+                        csi_out3: endpoint@7 {
+                            status = "disabled";
+                        };
+                    };
+                };
+            };
+            csi_chan4: channel@4 {
+                reg = <4>;
+                status = "disabled";
+                ports {
+                    #address-cells = <1>;
+                    #size-cells = <0>;
+                    csi_chan4_port0: port@0 {
+                        status = "disabled";
+                        reg = <0>;
+                        csi_in4: endpoint@8 {
+                            status = "disabled";
+                        };
+                    };
+                    csi_chan4_port1: port@1 {
+                        status = "disabled";
+                        reg = <1>;
+                        csi_out4: endpoint@9 {
+                            status = "disabled";
+                        };
+                    };
+                };
+            };
+            csi_chan5: channel@5 {
+                reg = <5>;
+                status = "disabled";
+                ports {
+                    #address-cells = <1>;
+                    #size-cells = <0>;
+                    csi_chan5_port0: port@0 {
+                        status = "disabled";
+                        reg = <0>;
+                        csi_in5: endpoint@10 {
+                            status = "disabled";
+                        };
+                    };
+                    csi_chan5_port1: port@1 {
+                        status = "disabled";
+                        reg = <1>;
+                        csi_out5: endpoint@11 {
+                            status = "disabled";
+                        };
+                    };
+                };
+            };
+        };
+    };
+
+    /*i2c@3180000 {
+        e3326_cam0: ov5693_c@36 {
+            status = "disabled";
+        };
+        e3323_cam0: ov23850_a@10 {
+            status = "disabled";
+        };
+        e3323_vcm0: lc898212@72 {
+            status = "disabled";
+        };
+        tca6408@21 {
+            status = "disabled";
+        };
+        tca9548@77 {
+            status = "disabled";
+            i2c@0 {
+                e3333_cam0: ov5693_a@36 {
+                    status = "disabled";
+                };
+                e3322_cam0: imx219_a@10 {
+                    status = "disabled";
+                };
+            };
+            i2c@1 {
+                e3333_cam1: ov5693_b@36 {
+                    status = "disabled";
+                };
+                e3322_cam1: imx219_b@10 {
+                    status = "disabled";
+                };
+            };
+            i2c@2 {
+                e3333_cam2: ov5693_c@36 {
+                    status = "disabled";
+                };
+                e3322_cam2: imx219_c@10 {
+                    status = "disabled";
+                };
+            };
+            i2c@3 {
+                e3333_cam3: ov5693_d@36 {
+                    status = "disabled";
+                };
+                e3322_cam3: imx219_d@10 {
+                    status = "disabled";
+                };
+            };
+            i2c@4 {
+                e3333_cam4: ov5693_e@36 {
+                    status = "disabled";
+                };
+                e3322_cam4: imx219_e@10 {
+                    status = "disabled";
+                };
+            };
+            i2c@5 {
+                e3333_cam5: ov5693_f@36 {
+                    status = "disabled";
+                };
+                e3322_cam5: imx219_f@10 {
+                    status = "disabled";
+                };
+            };
+        };
+        tca9546_70: tca9546@70 {
+            status = "disabled";
+            i2c@0 {
+                imx185_cam0: imx185_a@1a {
+                    status = "disabled";
+                };
+            };
+        };
+        tca9546_70: tca9546@70 {
+            status = "disabled";
+            i2c@0 {
+                imx274_cam0: imx274_a@1a {
+                    status = "disabled";
+                };
+            };
+        };
+    };
+
+    i2c@c240000 {
+        e3323_cam1: ov23850_c@36 {
+            status = "disabled";
+        };
+        e3323_vcm1: lc898212@72 {
+            status = "disabled";
+        };
+    };*/
+
+    tcp: tegra-camera-platform {
+        compatible = "nvidia, tegra-camera-platform";
+        modules {
+            cam_module0: module0 {
+                status = "disabled";
+                cam_module0_drivernode0: drivernode0 {
+                    status = "disabled";
+                };
+                cam_module0_drivernode1: drivernode1 {
+                    status = "disabled";
+                    pcl_id = "v4l2_lens";
+                };
+            };
+            cam_module1: module1 {
+                status = "disabled";
+                cam_module1_drivernode0: drivernode0 {
+                    status = "disabled";
+                };
+                cam_module1_drivernode1: drivernode1 {
+                    status = "disabled";
+                    pcl_id = "v4l2_lens";
+                };
+            };
+            cam_module2: module2 {
+                status = "disabled";
+                cam_module2_drivernode0: drivernode0 {
+                    status = "disabled";
+                };
+                cam_module2_drivernode1: drivernode1 {
+                    status = "disabled";
+                    pcl_id = "v4l2_lens";
+                };
+            };
+            cam_module3: module3 {
+                status = "disabled";
+                cam_module3_drivernode0: drivernode0 {
+                    status = "disabled";
+                };
+                cam_module3_drivernode1: drivernode1 {
+                    status = "disabled";
+                    pcl_id = "v4l2_lens";
+                };
+            };
+            cam_module4: module4 {
+                status = "disabled";
+                cam_module4_drivernode0: drivernode0 {
+                    status = "disabled";
+                };
+                cam_module4_drivernode1: drivernode1 {
+                    status = "disabled";
+                    pcl_id = "v4l2_lens";
+                };
+            };
+            cam_module5: module5 {
+                status = "disabled";
+                cam_module5_drivernode0: drivernode0 {
+                    status = "disabled";
+                };
+                cam_module5_drivernode1: drivernode1 {
+                    status = "disabled";
+                    pcl_id = "v4l2_lens";
+                };
+            };
+        };
+    };
+};
+

--- a/nvidia/platform/t18x/common/kernel-dts/t18x-common-platforms/tegra186-tx2-cti-power-tree.dtsi
+++ b/nvidia/platform/t18x/common/kernel-dts/t18x-common-platforms/tegra186-tx2-cti-power-tree.dtsi
@@ -1,0 +1,359 @@
+/*
+ * Copyright (c) 2015-2018, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ *
+ */
+
+#include "tegra186-quill-spmic-p3310-1000-a00-00.dtsi"
+#include "tegra186-cvb-prod-p2597-b00-p3310-1000-a00-00.dtsi"
+
+/ {
+
+	fixed-regulators {
+		vdd_1v8_ap: regulator@101 {
+			compatible = "regulator-fixed";
+			reg = <101>;
+			regulator-name = "vdd-1v8-ap";
+			regulator-min-microvolt = <1800000>;
+			regulator-max-microvolt = <1800000>;
+			regulator-always-on;
+			regulator-boot-on;
+		};
+	};
+
+
+	ether_qos@2490000 {
+		vddio_sys_enet_bias-supply = <&spmic_sd2>;
+		vddio_enet-supply = <&spmic_sd3>;
+		phy_vdd_1v8-supply = <&spmic_sd2>;
+		phy_ovdd_rgmii-supply = <&spmic_sd3>;
+		phy_pllvdd-supply = <&spmic_sd1>;
+	};
+
+	host1x {
+		nvdisplay@15200000 {
+			avdd_lcd-supply = <&en_avdd_disp_3v3>;
+			dvdd_lcd-supply = <&en_vdd_disp_1v8>;
+			avdd_dsi_csi-supply = <&spmic_sd1>;
+			outp-supply = <&vpp_lcd>;
+			outn-supply = <&vmm_lcd>;
+			vdd_lcd_bl-supply = <&battery_reg>;
+			vdd_lcd_bl_en-supply = <&vdd_bl_en>;
+			/* added hdmi for testing in head 0 */
+			avdd_hdmi-supply = <&spmic_ldo7>;
+			avdd_hdmi_pll-supply = <&spmic_sd2>;
+			vdd_hdmi_5v0-supply = <&vdd_hdmi>;
+		};
+		nvdisplay@15210000 {
+			avdd_hdmi-supply = <&spmic_ldo7>;
+			avdd_hdmi_pll-supply = <&spmic_sd2>;
+			vdd_hdmi_5v0-supply = <&vdd_hdmi>;
+		};
+		nvdisplay@15220000 {
+			vdd-dp-pwr-supply = <&battery_reg>;
+			avdd-dp-pll-supply = <&battery_reg>;
+			vdd-edp-sec-mode-supply = <&battery_reg>;
+			vdd-dp-pad-supply = <&battery_reg>;
+			vdd_hdmi_5v0-supply = <&battery_reg>;
+		};
+		vi@15700000 {
+			avdd_dsi_csi-supply = <&spmic_sd1>;
+		};
+		nvcsi@150c0000 {
+			nvidia,csi_regulator = "avdd_dsi_csi";
+		};
+	};
+
+	sdhci@3460000 {
+		vqmmc-supply = <&spmic_sd2>;
+		vmmc-supply = <&spmic_sd3>;
+	};
+
+	sdhci@3440000 {
+		vqmmc-supply = <&spmic_ldo5>;
+		vmmc-supply = <&spmic_sd2>;
+	};
+
+	sdhci@3420000 {
+		vqmmc-supply = <&spmic_sd2>;
+		vmmc-supply = <&spmic_sd3>;
+	};
+
+	sdhci@3400000 {
+		vqmmc-supply = <&spmic_ldo3>;
+		vmmc-supply = <&en_vdd_sdcard1>;
+	};
+
+	xhci@3530000 {
+		avddio_usb-supply = <&spmic_sd3>;
+		avdd_pll_utmip-supply = <&spmic_sd2>;
+		hvdd_usb-supply =  <&spmic_sd2>;
+	};
+
+	xudc@3550000 {
+		avdd-usb-supply = <&spmic_sd3>;
+	};
+
+	pinctrl@3520000 {
+		vbus-0-supply = <&vdd_usb0_5v>;
+		vbus-1-supply = <&vdd_usb1_5v>;
+		vbus-2-supply = <&vdd_usb2_5v>;
+		vbus-3-supply = <&battery_reg>;
+		vddio-hsic-supply = <&battery_reg>;
+		avdd_usb-supply = <&spmic_sd3>;
+		vclamp_usb-supply = <&spmic_sd2>;
+		avdd_pll_erefeut-supply = <&spmic_sd2>;
+	};
+
+	xusb_padctl@3520000 {
+		avdd_usb-supply = <&spmic_sd3>;
+		vclamp_usb-supply = <&spmic_sd2>;
+		avdd_pll_erefeut-supply = <&spmic_sd2>;
+	};
+
+	spi@c260000 {
+		spi-touch-sharp19x12@0 {
+			avdd-supply = <&en_vdd_ts_hv_3v3>;
+			dvdd-supply = <&en_vdd_ts_1v8>;
+		};
+	};
+
+	pcie-controller@10003000 {
+		dvdd-pex-supply = <&spmic_ldo7>;
+		hvdd-pex-pll-supply = <&spmic_sd2>;
+		hvdd-pex-supply = <&spmic_sd2>;
+		vddio-pexctl-aud-supply = <&spmic_sd2>;
+	};
+
+	pmc-iopower {
+		vddio-sys-supply = <&vdd_1v8_ap>;
+		vddio-uart-supply = <&vdd_1v8_ap>;
+		vddio-conn-supply = <&vdd_1v8_ap>;
+		vddio-edp-supply = <&vdd_1v8_ap>;
+		vddio-pex-ctrl-supply = <&vdd_1v8_ap>;
+		vddio-audio-supply = <&vdd_1v8_ap>;
+		vddio-ufs-supply = <&vdd_1v8_ap>;
+		vddio-ddr0-supply = <&spmic_sd0>;
+		vddio-ddr1-supply = <&spmic_sd0>;
+		vddio-mipi-bias-supply = <&spmic_sd1>;
+		vddio-cam-supply = <&vdd_1v8_ap>;
+		vddio-sdmmc4-supply = <&vdd_1v8_ap>;
+		vddio-sdmmc1-hv-supply = <&spmic_ldo3>;
+		vddio-audio-hv-supply = <&vdd_1v8_ap>;
+		vddio-dbg-supply = <&vdd_1v8_ap>;
+		vddio-spi-supply = <&vdd_1v8_ap>;
+		vddio-ao-supply = <&vdd_1v8_ap>;
+		vddio-ao-hv-supply = <&spmic_ldo2>;
+		vddio-dmic-hv-supply =  <&vdd_1v8_ap>;
+		vddio-sdmmc2-hv-supply = <&spmic_sd3>;
+		vddio-sdmmc3-hv-supply =  <&spmic_ldo5>;
+	};
+
+	i2c@c250000 {
+		tegra_tmp451: temp-sensor@4c {
+			vdd-supply = <&vdd_1v8_ap>;
+		};
+	};
+
+	pwm-fan {
+		vdd-fan-supply = <&battery_reg>;
+	};
+
+	bluedroid_pm {
+		avdd-supply = <&battery_reg>;
+		dvdd-supply = <&spmic_sd2>;
+	};
+
+	bpmp_i2c {
+		spmic@3c {
+			pinmux@0 {
+
+				pin_gpio1 {
+					maxim,active-fps-power-up-slot = <1>;
+					maxim,active-fps-power-down-slot = <3>;
+				};
+
+				pin_gpio2 {
+					maxim,active-fps-power-up-slot = <7>;
+					maxim,active-fps-power-down-slot = <1>;
+				};
+
+				pin_gpio3 {
+					maxim,active-fps-power-up-slot = <1>;
+					maxim,active-fps-power-down-slot = <7>;
+				};
+			};
+
+			regulators {
+				sd0 {
+					maxim,active-fps-source = <MAX77620_FPS_SRC_0>;
+					maxim,active-fps-power-up-slot = <5>;
+					maxim,active-fps-power-down-slot = <2>;
+					regulator-enable-ramp-delay = <278>;
+					regulator-disable-ramp-delay = <153000>;
+					maxim,ramp-rate-setting = <27500>;
+					regulator-ramp-delay = <3930>;
+				};
+
+				sd1 {
+					maxim,active-fps-source = <MAX77620_FPS_SRC_1>;
+					maxim,active-fps-power-up-slot = <3>;
+					maxim,active-fps-power-down-slot = <1>;
+					regulator-enable-ramp-delay = <211>;
+					regulator-disable-ramp-delay = <40000>;
+					maxim,ramp-rate-setting = <27500>;
+					regulator-ramp-delay = <5500>;
+				};
+
+				sd2 {
+					maxim,active-fps-source = <MAX77620_FPS_SRC_0>;
+					maxim,active-fps-power-up-slot = <0>;
+					maxim,active-fps-power-down-slot = <7>;
+					regulator-enable-ramp-delay = <4000>;
+					regulator-disable-ramp-delay = <21000>;
+					maxim,ramp-rate-setting = <27500>;
+					regulator-ramp-delay = <450>;
+				};
+
+				sd3 {
+					maxim,active-fps-source = <MAX77620_FPS_SRC_0>;
+					maxim,active-fps-power-up-slot = <6>;
+					maxim,active-fps-power-down-slot = <1>;
+					regulator-enable-ramp-delay = <574>;
+					regulator-disable-ramp-delay = <40000>;
+					maxim,ramp-rate-setting = <27500>;
+					regulator-ramp-delay = <5500>;
+				};
+
+				ldo0 {
+					maxim,active-fps-source = <MAX77620_FPS_SRC_1>;
+					maxim,active-fps-power-up-slot = <3>;
+					maxim,active-fps-power-down-slot = <3>;
+					maxim,ramp-rate-setting = <100000>;
+					regulator-ramp-delay = <100000>;
+				};
+
+				ldo1 {
+					maxim,ramp-rate-setting = <100000>;
+					regulator-ramp-delay = <100000>;
+				};
+
+				ldo2 {
+					maxim,active-fps-source = <MAX77620_FPS_SRC_0>;
+					maxim,active-fps-power-up-slot = <6>;
+					maxim,active-fps-power-down-slot = <1>;
+					regulator-enable-ramp-delay = <152>;
+					regulator-disable-ramp-delay = <14000>;
+					maxim,ramp-rate-setting = <100000>;
+					regulator-ramp-delay = <20000>;
+				};
+
+				ldo3 {
+					maxim,active-fps-source = <MAX77620_FPS_SRC_NONE>;
+					maxim,active-fps-power-up-slot = <0>;
+					maxim,active-fps-power-down-slot = <7>;
+					regulator-enable-ramp-delay = <160>;
+					regulator-disable-ramp-delay = <16000>;
+					maxim,ramp-rate-setting = <5000>;
+					regulator-ramp-delay = <1000>;
+				};
+
+				ldo4 {
+					maxim,active-fps-source = <MAX77620_FPS_SRC_0>;
+					maxim,active-fps-power-up-slot = <1>;
+					maxim,active-fps-power-down-slot = <7>;
+					regulator-enable-ramp-delay = <26>;
+					regulator-disable-ramp-delay = <1650>;
+					maxim,ramp-rate-setting = <100000>;
+					regulator-ramp-delay = <33000>;
+				};
+
+				ldo5 {
+					maxim,active-fps-power-up-slot = <0>;
+					maxim,active-fps-power-down-slot = <7>;
+					regulator-enable-ramp-delay = <309>;
+					regulator-disable-ramp-delay = <16000>;
+					maxim,ramp-rate-setting = <5000>;
+					regulator-ramp-delay = <526>;
+				};
+
+				ldo6 {
+					maxim,ramp-rate-setting = <100000>;
+					regulator-ramp-delay = <100000>;
+				};
+
+				ldo7 {
+					maxim,active-fps-source = <MAX77620_FPS_SRC_1>;
+					maxim,active-fps-power-up-slot = <4>;
+					maxim,active-fps-power-down-slot = <1>;
+					regulator-enable-ramp-delay = <95>;
+					regulator-disable-ramp-delay = <15000>;
+					maxim,ramp-rate-setting = <100000>;
+					regulator-ramp-delay = <10000>;
+				};
+
+			};
+		};
+	};
+
+	fixed-regulators {
+		regulator@1 {
+			regulator-enable-ramp-delay = <1120>;
+			regulator-disable-ramp-delay = <16500>;
+		};
+
+		regulator@2 {
+			regulator-enable-ramp-delay = <108>;
+			regulator-disable-ramp-delay = <1200>;
+		};
+
+		regulator@3 {
+			regulator-enable-ramp-delay = <745>;
+			regulator-disable-ramp-delay = <74000>;
+		};
+
+		regulator@4 {
+			regulator-enable-ramp-delay = <945>;
+			regulator-disable-ramp-delay = <2650>;
+		};
+
+		regulator@5 {
+			regulator-enable-ramp-delay = <800>;
+			regulator-disable-ramp-delay = <13000>;
+		};
+
+		regulator@6 {
+			regulator-enable-ramp-delay = <173>;
+			regulator-disable-ramp-delay = <13000>;
+		};
+
+		regulator@7 {
+			regulator-enable-ramp-delay = <245>;
+			regulator-disable-ramp-delay = <43000>;
+		};
+
+		regulator@8 {
+			regulator-enable-ramp-delay = <216>;
+			regulator-disable-ramp-delay = <43000>;
+		};
+
+		regulator@10 {
+			regulator-enable-ramp-delay = <178>;
+			regulator-disable-ramp-delay = <10000>;
+		};
+
+		regulator@11 {
+			regulator-enable-ramp-delay = <5000>;
+			regulator-disable-ramp-delay = <87000>;
+		};
+	};
+};

--- a/nvidia/platform/t18x/common/kernel-dts/t18x-common-plugin-manager/tegra186-tx2-cti-plugin-manager.dtsi
+++ b/nvidia/platform/t18x/common/kernel-dts/t18x-common-plugin-manager/tegra186-tx2-cti-plugin-manager.dtsi
@@ -1,0 +1,389 @@
+/*
+ * tegra186-quill-p3310-1000-a00-plugin-manager.dtsi: P3310 plugin manager
+ *
+ * Copyright (c) 2015-2017, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ */
+
+#include "tegra186-soc-prod-plugin-manager.dtsi"
+#include "tegra186-odm-data-plugin-manager.dtsi"
+#include "tegra186-quill-p3310-1000-300-plugin-manager.dtsi"
+
+/ {
+	eeprom-manager {
+		data-size = <0x100>;
+		boardid-with-revision = <3310>;
+		boardid-with-config = <3310>;
+		bus@0 {
+			i2c-bus = <&gen8_i2c>;
+			eeprom@0 {
+				slave-address = <0x50>;
+				label = "cvm";
+			};
+			eeprom@1 {
+				slave-address = <0x57>;
+				label = "cvb";
+			};
+		};
+		bus@1 {
+			i2c-bus = <&gen2_i2c>;
+			eeprom@0 {
+				slave-address = <0x51>;
+			};
+		};
+		bus@2 {
+			i2c-bus = <&gen1_i2c>;
+			eeprom@0 {
+				slave-address = <0x50>;
+			};
+		};
+		bus@3 {
+			i2c-bus = <&cam_i2c>;
+			eeprom@0 {
+				slave-address = <0x54>;
+				label = "cam";
+				enable-gpio = <2 9>;
+			};
+			eeprom@1 {
+				slave-address = <0x57>;
+				label = "cam";
+				enable-gpio = <2 9>;
+			};
+		};
+	};
+	plugin-manager {
+		fragment-devslp@0 {
+			ids = ">=3310-1000-200";
+			override@0 {
+				target = <&{/ahci-sata@3507000}>;
+				_overlay_ {
+					gpios = <&spmic 7 0>;
+				};
+			};
+			override@1 {
+				target = <&{/bpmp_i2c/spmic@3c/pinmux@0}>;
+				_overlay_ {
+					pin_gpio7 {
+						drive-push-pull = <1>;
+					};
+				};
+			};
+		};
+/*		fragment-e3325-xusb {
+			enable-override-on-all-matches;
+			ids = "<3310-1000-500";
+			odm-data = "enable-xusb-on-uphy-lane0";
+			override@0 {
+#if TEGRA_XUSB_PADCONTROL_VERSION >= DT_VERSION_2
+				target = <&xusb_padctl>;
+				_overlay_ {
+					ports {
+						usb2-2 {
+							status = "okay";
+						};
+						usb3-0 {
+							status = "okay";
+						};
+					};
+				};
+#else
+				target = <&tegra_xusb_padctl_pinmux_default>;
+				_overlay_ {
+					e3325-usb3-std-A-HS {
+						status = "okay";
+					};
+					e3325-usb3-std-A-SS {
+						status = "okay";
+					};
+				};
+#endif
+			};
+			override@1 {
+				target = <&{/xhci@3530000}>;
+#if TEGRA_XUSB_PADCONTROL_VERSION >= DT_VERSION_2
+				_overlay_ {
+					phys = <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-0}>,
+						<&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-1}>,
+						<&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-2}>,
+						<&{/xusb_padctl@3520000/pads/usb3/lanes/usb3-0}>,
+						<&{/xusb_padctl@3520000/pads/usb3/lanes/usb3-1}>;
+					phy-names = "usb2-0", "usb2-1", "usb2-2", "usb3-0", "usb3-1";
+				};
+#else
+				_overlay_ {
+					phys = <&tegra_xusb_padctl TEGRA_PADCTL_PHY_UTMI_P(0)>,
+							<&tegra_xusb_padctl TEGRA_PADCTL_PHY_UTMI_P(1)>,
+							<&tegra_xusb_padctl TEGRA_PADCTL_PHY_USB3_P(1)>,
+							<&tegra_xusb_padctl TEGRA_PADCTL_PHY_UTMI_P(2)>,
+							<&tegra_xusb_padctl TEGRA_PADCTL_PHY_USB3_P(0)>;
+					phy-names = "utmi-0", "utmi-1", "usb3-1", "utmi-2", "usb3-0";
+				};
+#endif
+			};
+			override@2 {
+				target = <&tegra_main_gpio>;
+				_overlay_ {
+					e3325_sdio_rst {
+						status = "okay";
+					};
+					e3325_lane0_mux {
+						status = "okay";
+					};
+				};
+			};
+			override@3 {
+				target = <&tegra_pcie>;
+				_overlay_ {
+					pci@1,0 {
+						nvidia,num-lanes = <2>;
+					};
+					pci@2,0 {
+						nvidia,num-lanes = <1>;
+					};
+					pci@3,0 {
+						nvidia,num-lanes = <1>;
+					};
+				};
+			};
+		};
+		fragment-500-pcie-config {
+			ids = ">=3310-1000-500";
+			override@0 {
+				target = <&tegra_pcie>;
+				_overlay_ {
+					pci@1,0 {
+						nvidia,num-lanes = <4>;
+					};
+					pci@2,0 {
+						nvidia,num-lanes = <0>;
+					};
+					pci@3,0 {
+						nvidia,num-lanes = <1>;
+					};
+				};
+			};
+		};*/
+
+		fragment-comms-a00-chip {
+			ids = "<3310-1000-500";
+			override@0 {
+				target = <&bcm4354>;
+				_overlay_ {
+					sdhci-host = <&sdmmc3>;
+					pwr-retry-cnt = <0>;
+					interrupt-parent = <&tegra_main_gpio>;
+					interrupts = <TEGRA_MAIN_GPIO(C, 0) 0x14>;
+					delete-target-property = "wlan-pwr-gpio";
+				};
+			};
+			override@1 {
+				target = <&tegra_main_gpio>;
+				_overlay_ {
+					wifi-wake-ap {
+						status = "okay";
+						gpios = <TEGRA_MAIN_GPIO(C, 0) 0>;
+					};
+
+					wifi-enable {
+						gpios = <TEGRA_MAIN_GPIO(B, 6) 0>;
+					};
+				};
+			};
+
+			override@3 {
+				target = <&tegra_aon_gpio>;
+				_overlay_ {
+					wifi-wake-ap {
+						status = "disabled";
+					};
+				};
+			};
+		};
+/*		fragment-500-xusb-config {
+			ids = ">=3310-1000-500";
+			override@0 {
+				target = <&{/xhci@3530000}>;
+#if TEGRA_XUSB_PADCONTROL_VERSION >= DT_VERSION_2
+				_overlay_ {
+					phys = <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-0}>,
+						<&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-1}>,
+						<&{/xusb_padctl@3520000/pads/usb3/lanes/usb3-0}>;
+					phy-names = "usb2-0", "usb2-1", "usb3-0";
+				};
+#else
+				_overlay_ {
+					phys = <&tegra_xusb_padctl TEGRA_PADCTL_PHY_UTMI_P(0)>,
+						<&tegra_xusb_padctl TEGRA_PADCTL_PHY_UTMI_P(1)>,
+						<&tegra_xusb_padctl TEGRA_PADCTL_PHY_UTMI_P(2)>,
+						<&tegra_xusb_padctl TEGRA_PADCTL_PHY_USB3_P(0)>;
+					phy-names = "utmi-0", "utmi-1", "utmi-2", "usb3-0";
+				};
+#endif
+			};
+			override@1 {
+#if TEGRA_XUSB_PADCONTROL_VERSION >= DT_VERSION_2
+				target = <&xusb_padctl>;
+				_overlay_ {
+					ports {
+						usb3-1 {
+							status = "disabled";
+						};
+						usb3-0 {
+							nvidia,usb2-companion = <1>;
+							status = "okay";
+						};
+					};
+				};
+#else
+				target = <&tegra_xusb_padctl_pinmux_default>;
+				_overlay_ {
+					usb3-std-A-port2 {
+						nvidia,lanes = "usb3-0";
+					};
+					e3325-usb3-std-A-HS {
+						status = "okay";
+					};
+				};
+#endif
+			};
+		};
+		fragment-500-e3325-pcie {
+			enable-override-on-all-matches;
+			ids = ">=3310-1000-500";
+			odm-data = "enable-pcie-on-uphy-lane0";
+			override@0 {
+				target = <&{/xhci@3530000}>;
+#if TEGRA_XUSB_PADCONTROL_VERSION >= DT_VERSION_2
+				_overlay_ {
+					phys = <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-0}>,
+						<&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-1}>;
+					phy-names = "usb2-0", "usb2-1";
+				};
+#else
+				_overlay_ {
+					phys = <&tegra_xusb_padctl TEGRA_PADCTL_PHY_UTMI_P(0)>,
+						<&tegra_xusb_padctl TEGRA_PADCTL_PHY_UTMI_P(1)>,
+						<&tegra_xusb_padctl TEGRA_PADCTL_PHY_UTMI_P(2)>;
+					phy-names = "utmi-0", "utmi-1", "utmi-2";
+				};
+#endif
+			};
+			override@1 {
+				target = <&tegra_xusb_padctl_pinmux_default>;
+				_overlay_ {
+					usb3-std-A-port2 {
+						status = "disabled";
+					};
+				};
+			};
+
+			override@2 {
+				target = <&tegra_main_gpio>;
+				_overlay_ {
+					pcie0_lane2_mux {
+						status = "okay";
+					};
+				};
+			};
+		};
+*/
+		fragment-e3320-dp {
+			ids = ">=3320-1000-000", ">=3320-1100-000";
+			override@0 {
+				target = <&{/host1x}>;
+				_overlay_ {
+					nvdisplay@15220000 {
+						status = "okay";
+					};
+					sor {
+						status = "okay";
+						dp-display {
+							status = "okay";
+						};
+					};
+					dpaux@155c0000 {
+						status = "okay";
+					};
+				};
+			};
+		};
+
+		fragment-p3310-c00-comm {
+			ids = ">=3310-1000-800";
+			override@0 {
+				target = <&{/bluedroid_pm}>;
+				_overlay_ {
+					bluedroid_pm,reset-gpio = <&tegra_main_gpio TEGRA_MAIN_GPIO(H, 5) 0>;
+				};
+			};
+		};
+
+		fragment-p3310-c00-pmic {
+			ids = ">=3310-1000-800";
+			override@0 {
+				target = <&spmic_ldo6>;
+				_overlay_ {
+					maxim,active-fps-source = <MAX77620_FPS_SRC_NONE>;
+				};
+			};
+		};
+
+		fragment-p3310-c01 {
+			ids = ">=3310-1000-900";
+			override@0 {
+				target = <&{/bpmp_i2c/spmic@3c/regulators/ldo6}>;
+				_overlay_ {
+					regulator-boot-on;
+					regulator-always-on;
+				};
+			};
+			override@1 {
+				target = <&{/bpmp_i2c/spmic@3c/pinmux@0}>;
+				_overlay_ {
+					pin_gpio2 {
+						status = "disabled";
+					};
+					pin_gpio3 {
+						status = "disabled";
+					};
+				};
+			};
+		};
+
+		fragment-p3310-c03 {
+			ids = ">=3310-1000-B00";
+
+			override@1 {
+				target = <&spmic_ldo8>;
+				_overlay_ {
+					regulator-name = "dvdd-pex";
+					regulator-min-microvolt = <1000000>;
+					regulator-max-microvolt = <1000000>;
+				};
+			};
+
+			override@2 {
+				target = <&spmic_ldo0>;
+				_overlay_ {
+					maxim,active-fps-source = <MAX77620_FPS_SRC_NONE>;
+				};
+			};
+
+			override@3 {
+				target = <&spmic_ldo7>;
+				_overlay_ {
+					regulator-min-microvolt = <1000000>;
+					regulator-max-microvolt = <1000000>;
+				};
+			};
+		};
+	};
+};

--- a/nvidia/platform/t18x/quill/kernel-dts/Makefile
+++ b/nvidia/platform/t18x/quill/kernel-dts/Makefile
@@ -30,6 +30,26 @@ dtb-$(CONFIG_ARCH_TEGRA_18x_SOC) += tegra186-quill-p3489-1000-a00-00-e2598.dtb
 dtb-$(CONFIG_ARCH_TEGRA_18x_SOC) += tegra186-quill-p3489-0888-a00-00-base.dtb
 dtb-$(CONFIG_ARCH_TEGRA_18x_SOC) += tegra186-quill-p3489-0888-a00-00-e2598.dtb
 
+
+dtb-$(CONFIG_ARCH_TEGRA_18x_SOC) += tegra186-tx2-cti-ASG001-revG+.dtb
+dtb-$(CONFIG_ARCH_TEGRA_18x_SOC) += tegra186-tx2-cti-ASG001-USB3.dtb
+dtb-$(CONFIG_ARCH_TEGRA_18x_SOC) += tegra186-tx2-cti-ASG001-mPCIe.dtb
+dtb-$(CONFIG_ARCH_TEGRA_18x_SOC) += tegra186-tx2-cti-ASG002-revF+.dtb
+dtb-$(CONFIG_ARCH_TEGRA_18x_SOC) += tegra186-tx2-cti-ASG002-USB3.dtb
+dtb-$(CONFIG_ARCH_TEGRA_18x_SOC) += tegra186-tx2-cti-ASG002-mPCIe.dtb
+dtb-$(CONFIG_ARCH_TEGRA_18x_SOC) += tegra186-tx2-cti-ASG003.dtb
+dtb-$(CONFIG_ARCH_TEGRA_18x_SOC) += tegra186-tx2-cti-ESG503.dtb
+dtb-$(CONFIG_ARCH_TEGRA_18x_SOC) += tegra186-tx2-cti-ESG503-USB3.dtb
+dtb-$(CONFIG_ARCH_TEGRA_18x_SOC) += tegra186-tx2-cti-ESG503-mPCIe.dtb
+dtb-$(CONFIG_ARCH_TEGRA_18x_SOC) += tegra186-tx2-cti-ASG006-base.dtb
+dtb-$(CONFIG_ARCH_TEGRA_18x_SOC) += tegra186-tx2-cti-ASG007.dtb
+dtb-$(CONFIG_ARCH_TEGRA_18x_SOC) += tegra186-tx2-cti-ASG008-base.dtb
+dtb-$(CONFIG_ARCH_TEGRA_18x_SOC) += tegra186-tx2-cti-VPG003.dtb
+dtb-$(CONFIG_ARCH_TEGRA_18x_SOC) += tegra186-tx2-cti-ASG006-IMX274-3CAM.dtb
+dtb-$(CONFIG_ARCH_TEGRA_18x_SOC) += tegra186-tx2-cti-ASG006-IMX274-6CAM.dtb
+dtb-$(CONFIG_ARCH_TEGRA_18x_SOC) += tegra186-tx2-cti-ASG006-IMX185-3CAM.dtb
+dtb-$(CONFIG_ARCH_TEGRA_18x_SOC) += tegra186-tx2-cti-ASG006-IMX185-6CAM.dtb
+
 dtbo-$(CONFIG_ARCH_TEGRA_18x_SOC) += tegra186-quill-p3310-1000-a00-overlay.dtbo
 dtb-$(CONFIG_ARCH_TEGRA_18x_SOC) += tegra186-quill-p3310-1000-as-0888.dtb
 

--- a/nvidia/platform/t18x/quill/kernel-dts/tegra186-tx2-cti-ASG001-USB3.dts
+++ b/nvidia/platform/t18x/quill/kernel-dts/tegra186-tx2-cti-ASG001-USB3.dts
@@ -1,0 +1,133 @@
+#include <tegra186-tx2-cti-base.dts>
+
+/{
+    nvidia,dtsfilename = "tegra186-tx2-cti-ASG001-USB3.dts";
+
+    gpio@2200000 {
+    /*enable this to enabled PCIe Controller #2*/
+        pcie0_lane2_mux {
+             status = "disable";
+        };
+    /******************************************/
+    /*enable these two to enable USB3 Port 0*/
+        e3325_sdio_rst {
+           status = "okay";
+        };
+        e3325_lane0_mux {
+            status = "okay";
+        };
+    /******************************************/
+
+    };
+
+
+
+    xhci@3530000 {
+        status = "okay";
+        phys = <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-0}>,
+            <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-1}>,
+            <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-2}>,
+            <&{/xusb_padctl@3520000/pads/usb3/lanes/usb3-0}>;
+        phy-names = "usb2-0", "usb2-1", "usb2-2", "usb3-0";
+    };
+
+
+   xusb_padctl@3520000 {
+        pads {
+            usb2 {
+                lanes {
+                    usb2-0 {
+                        status = "okay";
+                    };
+                    usb2-1 {
+                        status = "okay";
+                    };
+                    usb2-2 {
+                        status = "okay";
+                    };
+                };
+            };
+            usb3 {
+                lanes {
+                    usb3-0 {
+                        status = "okay";
+                    };
+                    usb3-1 {
+                        status = "disabled";
+                    };
+                    usb3-2 {
+                        status = "disabled";
+                    };
+                };
+            };
+        };
+        ports {
+            usb2-0 {
+                status = "okay";
+            };
+            usb2-1 {
+                status = "okay";
+            };
+
+            usb2-2 {
+                status = "okay";
+            };
+
+            usb3-0 {
+                nvidia,usb2-companion = <0>;
+                status = "okay";
+            };
+            usb3-1 {
+                nvidia,usb2-companion = <1>;
+                status = "disabled";
+            };
+            usb3-2 {
+                nvidia,usb2-companion = <2>;
+                status = "disabled";
+            };
+        };
+    };
+    pinctrl@3520000 {
+        status = "okay";
+           pinmux {
+            usb2-port0 {
+                status = "okay";
+            };
+            usb2-port1 {
+                status = "okay";
+            };
+
+            usb2-port2 {
+                status = "okay";
+            };
+
+            usb3-port0 {
+                status = "okay";
+            };
+
+            usb3-port1 {
+                status = "disabled";
+            };
+
+            usb3-port2 {
+                status = "disabled";
+            };
+        };
+    };
+    pcie-controller@10003000 {
+        pci@1,0 {
+            nvidia,num-lanes = <1>;
+            status = "okay";
+        };
+        pci@2,0 {
+            nvidia,num-lanes = <0>;
+            status = "disabled";
+        };
+        pci@3,0 {
+            nvidia,num-lanes = <1>;
+            status = "okay";
+        };
+    };
+
+
+};

--- a/nvidia/platform/t18x/quill/kernel-dts/tegra186-tx2-cti-ASG001-mPCIe.dts
+++ b/nvidia/platform/t18x/quill/kernel-dts/tegra186-tx2-cti-ASG001-mPCIe.dts
@@ -1,0 +1,133 @@
+#include <tegra186-tx2-cti-base.dts>
+
+/{
+    nvidia,dtsfilename = "tegra186-tx2-cti-ASG001-mPCIe.dts";
+
+    gpio@2200000 {
+    /*enable this to enabled PCIe Controller #2*/
+        pcie0_lane2_mux {
+             status = "okay";
+        };
+    /******************************************/
+    /*enable these two to enable USB3 Port 0*/
+        e3325_sdio_rst {
+           status = "disabled";
+        };
+        e3325_lane0_mux {
+            status = "disabled";
+        };
+    /******************************************/
+
+    };
+
+
+
+    xhci@3530000 {
+        status = "okay";
+        phys = <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-0}>,
+            <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-1}>,
+            <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-2}>,
+            <&{/xusb_padctl@3520000/pads/usb3/lanes/usb3-1}>;
+        phy-names = "usb2-0", "usb2-1", "usb2-2", "usb3-1";
+    };
+
+
+   xusb_padctl@3520000 {
+        pads {
+            usb2 {
+                lanes {
+                    usb2-0 {
+                        status = "okay";
+                    };
+                    usb2-1 {
+                        status = "okay";
+                    };
+                    usb2-2 {
+                        status = "okay";
+                    };
+                };
+            };
+            usb3 {
+                lanes {
+                    usb3-0 {
+                        status = "disabled";
+                    };
+                    usb3-1 {
+                        status = "okay";
+                    };
+                    usb3-2 {
+                        status = "disabled";
+                    };
+                };
+            };
+        };
+        ports {
+            usb2-0 {
+                status = "okay";
+            };
+            usb2-1 {
+                status = "okay";
+            };
+
+            usb2-2 {
+                status = "okay";
+            };
+
+            usb3-0 {
+                nvidia,usb2-companion = <0>;
+                status = "disabled";
+            };
+            usb3-1 {
+                nvidia,usb2-companion = <1>;
+                status = "okay";
+            };
+            usb3-2 {
+                nvidia,usb2-companion = <2>;
+                status = "disabled";
+            };
+        };
+    };
+    pinctrl@3520000 {
+        status = "okay";
+           pinmux {
+            usb2-port0 {
+                status = "okay";
+            };
+            usb2-port1 {
+                status = "okay";
+            };
+
+            usb2-port2 {
+                status = "okay";
+            };
+
+            usb3-port0 {
+                status = "disabled";
+            };
+
+            usb3-port1 {
+                status = "okay";
+            };
+
+            usb3-port2 {
+                status = "disabled";
+            };
+        };
+    };
+    pcie-controller@10003000 {
+        pci@1,0 {
+            nvidia,num-lanes = <1>;
+            status = "okay";
+        };
+        pci@2,0 {
+            nvidia,num-lanes = <0>;
+            status = "disabled";
+        };
+        pci@3,0 {
+            nvidia,num-lanes = <1>;
+            status = "okay";
+        };
+    };
+
+
+};

--- a/nvidia/platform/t18x/quill/kernel-dts/tegra186-tx2-cti-ASG001-revG+.dts
+++ b/nvidia/platform/t18x/quill/kernel-dts/tegra186-tx2-cti-ASG001-revG+.dts
@@ -1,0 +1,134 @@
+#include <tegra186-tx2-cti-base.dts>
+//#include <tegra186-tx2-cti-audio-ASG001.dtsi>
+
+/{
+    nvidia,dtsfilename = "tegra186-tx2-cti-ASG001-revG+.dts";
+
+    gpio@2200000 {
+    /*enable this to enabled PCIe Controller #2*/
+        pcie0_lane2_mux {
+             status = "okay";
+        };
+    /******************************************/
+    /*enable these two to enable USB3 Port 0*/
+        e3325_sdio_rst {
+           status = "disabled";
+        };
+        e3325_lane0_mux {
+            status = "disabled";
+        };
+    /******************************************/
+
+    };
+
+
+
+    xhci@3530000 {
+        status = "okay";
+        phys = <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-0}>,
+            <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-1}>,
+            <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-2}>,
+            <&{/xusb_padctl@3520000/pads/usb3/lanes/usb3-1}>;
+        phy-names = "usb2-0", "usb2-1", "usb2-2", "usb3-1";
+    };
+
+
+   xusb_padctl@3520000 {
+        pads {
+            usb2 {
+                lanes {
+                    usb2-0 {
+                        status = "okay";
+                    };
+                    usb2-1 {
+                        status = "okay";
+                    };
+                    usb2-2 {
+                        status = "okay";
+                    };
+                };
+            };
+            usb3 {
+                lanes {
+                    usb3-0 {
+                        status = "disabled";
+                    };
+                    usb3-1 {
+                        status = "okay";
+                    };
+                    usb3-2 {
+                        status = "disabled";
+                    };
+                };
+            };
+        };
+        ports {
+            usb2-0 {
+                status = "okay";
+            };
+            usb2-1 {
+                status = "okay";
+            };
+
+            usb2-2 {
+                status = "okay";
+            };
+
+            usb3-0 {
+                nvidia,usb2-companion = <0>;
+                status = "disabled";
+            };
+            usb3-1 {
+                nvidia,usb2-companion = <1>;
+                status = "okay";
+            };
+            usb3-2 {
+                nvidia,usb2-companion = <2>;
+                status = "disabled";
+            };
+        };
+    };
+    pinctrl@3520000 {
+        status = "okay";
+           pinmux {
+            usb2-port0 {
+                status = "okay";
+            };
+            usb2-port1 {
+                status = "okay";
+            };
+
+            usb2-port2 {
+                status = "okay";
+            };
+
+            usb3-port0 {
+                status = "disabled";
+            };
+
+            usb3-port1 {
+                status = "okay";
+            };
+
+            usb3-port2 {
+                status = "disabled";
+            };
+        };
+    };
+    pcie-controller@10003000 {
+        pci@1,0 {
+            nvidia,num-lanes = <1>;
+            status = "okay";
+        };
+        pci@2,0 {
+            nvidia,num-lanes = <0>;
+            status = "disabled";
+        };
+        pci@3,0 {
+            nvidia,num-lanes = <1>;
+            status = "okay";
+        };
+    };
+
+
+};

--- a/nvidia/platform/t18x/quill/kernel-dts/tegra186-tx2-cti-ASG002-USB3.dts
+++ b/nvidia/platform/t18x/quill/kernel-dts/tegra186-tx2-cti-ASG002-USB3.dts
@@ -1,0 +1,133 @@
+#include <tegra186-tx2-cti-base.dts>
+
+/{
+    nvidia,dtsfilename = "tegra186-tx2-cti-ASG002-USB3.dts";
+
+    gpio@2200000 {
+    /*enable this to enabled PCIe Controller #2*/
+        pcie0_lane2_mux {
+             status = "disable";
+        };
+    /******************************************/
+    /*enable these two to enable USB3 Port 0*/
+        e3325_sdio_rst {
+           status = "okay";
+        };
+        e3325_lane0_mux {
+            status = "okay";
+        };
+    /******************************************/
+
+    };
+
+
+
+    xhci@3530000 {
+        status = "okay";
+        phys = <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-0}>,
+            <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-1}>,
+            <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-2}>,
+            <&{/xusb_padctl@3520000/pads/usb3/lanes/usb3-0}>;
+        phy-names = "usb2-0", "usb2-1", "usb2-2", "usb3-0";
+    };
+
+
+   xusb_padctl@3520000 {
+        pads {
+            usb2 {
+                lanes {
+                    usb2-0 {
+                        status = "okay";
+                    };
+                    usb2-1 {
+                        status = "okay";
+                    };
+                    usb2-2 {
+                        status = "okay";
+                    };
+                };
+            };
+            usb3 {
+                lanes {
+                    usb3-0 {
+                        status = "okay";
+                    };
+                    usb3-1 {
+                        status = "disabled";
+                    };
+                    usb3-2 {
+                        status = "disabled";
+                    };
+                };
+            };
+        };
+        ports {
+            usb2-0 {
+                status = "okay";
+            };
+            usb2-1 {
+                status = "okay";
+            };
+
+            usb2-2 {
+                status = "okay";
+            };
+
+            usb3-0 {
+                nvidia,usb2-companion = <0>;
+                status = "okay";
+            };
+            usb3-1 {
+                nvidia,usb2-companion = <1>;
+                status = "disabled";
+            };
+            usb3-2 {
+                nvidia,usb2-companion = <2>;
+                status = "disabled";
+            };
+        };
+    };
+    pinctrl@3520000 {
+        status = "okay";
+           pinmux {
+            usb2-port0 {
+                status = "okay";
+            };
+            usb2-port1 {
+                status = "okay";
+            };
+
+            usb2-port2 {
+                status = "okay";
+            };
+
+            usb3-port0 {
+                status = "okay";
+            };
+
+            usb3-port1 {
+                status = "disabled";
+            };
+
+            usb3-port2 {
+                status = "disabled";
+            };
+        };
+    };
+    pcie-controller@10003000 {
+        pci@1,0 {
+            nvidia,num-lanes = <1>;
+            status = "okay";
+        };
+        pci@2,0 {
+            nvidia,num-lanes = <0>;
+            status = "disabled";
+        };
+        pci@3,0 {
+            nvidia,num-lanes = <1>;
+            status = "okay";
+        };
+    };
+
+
+};

--- a/nvidia/platform/t18x/quill/kernel-dts/tegra186-tx2-cti-ASG002-mPCIe.dts
+++ b/nvidia/platform/t18x/quill/kernel-dts/tegra186-tx2-cti-ASG002-mPCIe.dts
@@ -1,0 +1,133 @@
+#include <tegra186-tx2-cti-base.dts>
+
+/{
+    nvidia,dtsfilename = "tegra186-tx2-cti-ASG002-mPCIe.dts";
+
+    gpio@2200000 {
+    /*enable this to enabled PCIe Controller #2*/
+        pcie0_lane2_mux {
+             status = "okay";
+        };
+    /******************************************/
+    /*enable these two to enable USB3 Port 0*/
+        e3325_sdio_rst {
+           status = "disabled";
+        };
+        e3325_lane0_mux {
+            status = "disabled";
+        };
+    /******************************************/
+
+    };
+
+
+
+    xhci@3530000 {
+        status = "okay";
+        phys = <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-0}>,
+            <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-1}>,
+            <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-2}>,
+            <&{/xusb_padctl@3520000/pads/usb3/lanes/usb3-1}>;
+        phy-names = "usb2-0", "usb2-1", "usb2-2", "usb3-1";
+    };
+
+
+   xusb_padctl@3520000 {
+        pads {
+            usb2 {
+                lanes {
+                    usb2-0 {
+                        status = "okay";
+                    };
+                    usb2-1 {
+                        status = "okay";
+                    };
+                    usb2-2 {
+                        status = "okay";
+                    };
+                };
+            };
+            usb3 {
+                lanes {
+                    usb3-0 {
+                        status = "disabled";
+                    };
+                    usb3-1 {
+                        status = "okay";
+                    };
+                    usb3-2 {
+                        status = "disabled";
+                    };
+                };
+            };
+        };
+        ports {
+            usb2-0 {
+                status = "okay";
+            };
+            usb2-1 {
+                status = "okay";
+            };
+
+            usb2-2 {
+                status = "okay";
+            };
+
+            usb3-0 {
+                nvidia,usb2-companion = <0>;
+                status = "disabled";
+            };
+            usb3-1 {
+                nvidia,usb2-companion = <1>;
+                status = "okay";
+            };
+            usb3-2 {
+                nvidia,usb2-companion = <2>;
+                status = "disabled";
+            };
+        };
+    };
+    pinctrl@3520000 {
+        status = "okay";
+           pinmux {
+            usb2-port0 {
+                status = "okay";
+            };
+            usb2-port1 {
+                status = "okay";
+            };
+
+            usb2-port2 {
+                status = "okay";
+            };
+
+            usb3-port0 {
+                status = "disabled";
+            };
+
+            usb3-port1 {
+                status = "okay";
+            };
+
+            usb3-port2 {
+                status = "disabled";
+            };
+        };
+    };
+    pcie-controller@10003000 {
+        pci@1,0 {
+            nvidia,num-lanes = <1>;
+            status = "okay";
+        };
+        pci@2,0 {
+            nvidia,num-lanes = <0>;
+            status = "disabled";
+        };
+        pci@3,0 {
+            nvidia,num-lanes = <1>;
+            status = "okay";
+        };
+    };
+
+
+};

--- a/nvidia/platform/t18x/quill/kernel-dts/tegra186-tx2-cti-ASG002-revF+.dts
+++ b/nvidia/platform/t18x/quill/kernel-dts/tegra186-tx2-cti-ASG002-revF+.dts
@@ -1,0 +1,133 @@
+#include <tegra186-tx2-cti-base.dts>
+
+/{
+    nvidia,dtsfilename = "tegra186-tx2-cti-ASG002-revF+.dts";
+
+    gpio@2200000 {
+    /*enable this to enabled PCIe Controller #2*/
+        pcie0_lane2_mux {
+             status = "okay";
+        };
+    /******************************************/
+    /*enable these two to enable USB3 Port 0*/
+        e3325_sdio_rst {
+           status = "disabled";
+        };
+        e3325_lane0_mux {
+            status = "disabled";
+        };
+    /******************************************/
+
+    };
+
+
+
+    xhci@3530000 {
+        status = "okay";
+        phys = <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-0}>,
+            <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-1}>,
+            <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-2}>,
+            <&{/xusb_padctl@3520000/pads/usb3/lanes/usb3-1}>;
+        phy-names = "usb2-0", "usb2-1", "usb2-2", "usb3-1";
+    };
+
+
+   xusb_padctl@3520000 {
+        pads {
+            usb2 {
+                lanes {
+                    usb2-0 {
+                        status = "okay";
+                    };
+                    usb2-1 {
+                        status = "okay";
+                    };
+                    usb2-2 {
+                        status = "okay";
+                    };
+                };
+            };
+            usb3 {
+                lanes {
+                    usb3-0 {
+                        status = "disabled";
+                    };
+                    usb3-1 {
+                        status = "okay";
+                    };
+                    usb3-2 {
+                        status = "disabled";
+                    };
+                };
+            };
+        };
+        ports {
+            usb2-0 {
+                status = "okay";
+            };
+            usb2-1 {
+                status = "okay";
+            };
+
+            usb2-2 {
+                status = "okay";
+            };
+
+            usb3-0 {
+                nvidia,usb2-companion = <0>;
+                status = "disabled";
+            };
+            usb3-1 {
+                nvidia,usb2-companion = <1>;
+                status = "okay";
+            };
+            usb3-2 {
+                nvidia,usb2-companion = <2>;
+                status = "disabled";
+            };
+        };
+    };
+    pinctrl@3520000 {
+        status = "okay";
+           pinmux {
+            usb2-port0 {
+                status = "okay";
+            };
+            usb2-port1 {
+                status = "okay";
+            };
+
+            usb2-port2 {
+                status = "okay";
+            };
+
+            usb3-port0 {
+                status = "disabled";
+            };
+
+            usb3-port1 {
+                status = "okay";
+            };
+
+            usb3-port2 {
+                status = "disabled";
+            };
+        };
+    };
+    pcie-controller@10003000 {
+        pci@1,0 {
+            nvidia,num-lanes = <2>;
+            status = "okay";
+        };
+        pci@2,0 {
+            nvidia,num-lanes = <1>;
+            status = "okay";
+        };
+        pci@3,0 {
+            nvidia,num-lanes = <1>;
+            status = "okay";
+        };
+    };
+
+
+};

--- a/nvidia/platform/t18x/quill/kernel-dts/tegra186-tx2-cti-ASG003.dts
+++ b/nvidia/platform/t18x/quill/kernel-dts/tegra186-tx2-cti-ASG003.dts
@@ -1,0 +1,133 @@
+#include <tegra186-tx2-cti-base.dts>
+
+/{
+    nvidia,dtsfilename = "tegra186-tx2-cti-ASG003.dts";
+
+    gpio@2200000 {
+    /*enable this to enabled PCIe Controller #2*/
+        pcie0_lane2_mux {
+             status = "disable";
+        };
+    /******************************************/
+    /*enable these two to enable USB3 Port 0*/
+        e3325_sdio_rst {
+           status = "okay";
+        };
+        e3325_lane0_mux {
+            status = "okay";
+        };
+    /******************************************/
+
+    };
+
+
+
+    xhci@3530000 {
+        status = "okay";
+        phys = <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-0}>,
+            <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-1}>,
+            <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-2}>,
+            <&{/xusb_padctl@3520000/pads/usb3/lanes/usb3-0}>;
+        phy-names = "usb2-0", "usb2-1", "usb2-2", "usb3-0";
+    };
+
+
+   xusb_padctl@3520000 {
+        pads {
+            usb2 {
+                lanes {
+                    usb2-0 {
+                        status = "okay";
+                    };
+                    usb2-1 {
+                        status = "okay";
+                    };
+                    usb2-2 {
+                        status = "okay";
+                    };
+                };
+            };
+            usb3 {
+                lanes {
+                    usb3-0 {
+                        status = "okay";
+                    };
+                    usb3-1 {
+                        status = "disabled";
+                    };
+                    usb3-2 {
+                        status = "disabled";
+                    };
+                };
+            };
+        };
+        ports {
+            usb2-0 {
+                status = "okay";
+            };
+            usb2-1 {
+                status = "okay";
+            };
+
+            usb2-2 {
+                status = "okay";
+            };
+
+            usb3-0 {
+                nvidia,usb2-companion = <1>;
+                status = "okay";
+            };
+            usb3-1 {
+                nvidia,usb2-companion = <0>;
+                status = "disabled";
+            };
+            usb3-2 {
+                nvidia,usb2-companion = <2>;
+                status = "disabled";
+            };
+        };
+    };
+    pinctrl@3520000 {
+        status = "okay";
+           pinmux {
+            usb2-port0 {
+                status = "okay";
+            };
+            usb2-port1 {
+                status = "okay";
+            };
+
+            usb2-port2 {
+                status = "okay";
+            };
+
+            usb3-port0 {
+                status = "okay";
+            };
+
+            usb3-port1 {
+                status = "disabled";
+            };
+
+            usb3-port2 {
+                status = "disabled";
+            };
+        };
+    };
+    pcie-controller@10003000 {
+        pci@1,0 {
+            nvidia,num-lanes = <4>;
+            status = "okay";
+        };
+        pci@2,0 {
+            nvidia,num-lanes = <0>;
+            status = "disabled";
+        };
+        pci@3,0 {
+            nvidia,num-lanes = <1>;
+            status = "okay";
+        };
+    };
+
+
+};

--- a/nvidia/platform/t18x/quill/kernel-dts/tegra186-tx2-cti-ASG006-IMX185-3CAM.dts
+++ b/nvidia/platform/t18x/quill/kernel-dts/tegra186-tx2-cti-ASG006-IMX185-3CAM.dts
@@ -1,0 +1,1068 @@
+#include <tegra186-tx2-cti-ASG006-base.dts>
+
+    
+
+#include <t18x-common-platforms/tegra186-tx2-cti-camera-base.dtsi>
+#include "dt-bindings/clock/tegra186-clock.h"
+
+
+/* camera control gpio definitions */
+
+#define CAM0_RST_L  TEGRA_MAIN_GPIO(R, 5)
+#define CAM0_PWDN   TEGRA_MAIN_GPIO(R, 0)
+#define CAM1_RST_L  TEGRA_MAIN_GPIO(R, 1)
+#define CAM1_PWDN   TEGRA_MAIN_GPIO(N, 2)
+
+
+/ {
+    
+    gpio@2200000 {
+        camera-control-output-low {
+            gpio-hog;
+            output-low;
+            gpios = <CAM0_RST_L 0 CAM0_PWDN 0
+                 CAM1_RST_L 0 CAM1_PWDN 0>;
+            label = "cam0-rst", "cam0-pwdn",
+                "cam1-rst", "cam1-pwdn";
+        };
+    };
+
+
+/**********************SENSORS******************************************************************/
+
+	i2c@3180000 {       //set this to correct i2c bus 
+        tca9546@70 {    
+            i2c@0{  //cam_i2c/Mux@70/I2C_A
+                #address-cells = <1>;
+                #size-cells = <0>;
+
+                imx185_a@1a {
+                    compatible = "nvidia,imx185";
+                    reg = <0x1a>;
+                    devnode = "video0";
+
+                    /* Physical dimensions of sensor */
+                    physical_w = "15.0";
+					physical_h = "12.5";
+                    clocks = <&tegra_car TEGRA186_CLK_EXTPERIPH1>,
+                             <&tegra_car TEGRA186_CLK_PLLP_OUT0>;
+                    clock-names = "extperiph1", "pllp_grtba";
+                    mclk = "extperiph1";
+                    sensor_model = "imx185";
+                    delayed_gain = "true";
+                    reset-gpios = <&tegra_main_gpio CAM0_RST_L GPIO_ACTIVE_HIGH>;                    
+					post_crop_frame_drop = "0";
+                    use_decibel_gain = "true";
+					
+                    mode0 {/*mode IMX185_MODE_1920X1080_CROP_30FPS*/
+						mclk_khz = "37125";
+						num_lanes = "4";
+						tegra_sinterface = "serial_a";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "12";
+						csi_pixel_bit_depth = "12";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2200";
+						inherent_gain = "1";
+						mclk_multiplier = "2";
+						pix_clk_hz = "74250000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "480"; /* 48dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain = "0";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "30000000"; /* 30 */
+						step_framerate = "1";
+						default_framerate = "30000000";
+						exposure_factor = "1000000";
+						min_exp_time = "30"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "33334";/* us */
+						embedded_metadata_height = "1";
+					};
+					mode1 {/*mode IMX185_MODE_1920X1080_CROP_10BIT_30FPS*/
+						mclk_khz = "37125";
+						num_lanes = "4";
+						tegra_sinterface = "serial_a";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "10";
+						csi_pixel_bit_depth = "10";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2640";
+						inherent_gain = "1";
+						mclk_multiplier = "2.4";
+						pix_clk_hz = "89100000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "480"; /* 48dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain ="0";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "30000000"; /* 30 */
+						step_framerate = "1";
+						default_framerate = "30000000";
+						exposure_factor = "1000000";
+						min_exp_time = "30"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "33334";/* us */
+						embedded_metadata_height = "1";
+					};
+
+					mode2 {/*mode IMX185_MODE_1920X1080_CROP_60FPS*/
+						mclk_khz = "37125";
+						num_lanes = "4";
+						tegra_sinterface = "serial_a";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "12";
+						csi_pixel_bit_depth = "12";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2200";
+						inherent_gain = "1";
+						mclk_multiplier = "4";
+						pix_clk_hz = "148500000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "480"; /* 48dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain = "0";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "60000000"; /* 60 */
+						step_framerate = "1";
+						default_framerate = "60000000";
+						exposure_factor = "1000000";
+						min_exp_time = "30"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "16667";/* us */
+						embedded_metadata_height = "1";
+					};
+
+					mode3 {/*mode IMX185_MODE_1920X1080_CROP_10BIT_60FPS*/
+						mclk_khz = "37125";
+						num_lanes = "4";
+						tegra_sinterface = "serial_a";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "10";
+						csi_pixel_bit_depth = "10";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2640";
+						inherent_gain = "1";
+						mclk_multiplier = "4.8";
+						pix_clk_hz = "178200000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "480"; /* 48dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain = "0";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "60000000"; /* 60 */
+						step_framerate = "1";
+						default_framerate = "60000000";
+						exposure_factor = "1000000";
+						min_exp_time = "30"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "16667";/* us */
+						embedded_metadata_height = "1";
+					};
+					mode4 {/*mode IMX185_MODE_1920X1080_CROP_HDR_30FPS*/
+						mclk_khz = "37125";
+						num_lanes = "4";
+						tegra_sinterface = "serial_a";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "16";
+						csi_pixel_bit_depth = "12";
+						mode_type = "bayer_wdr_pwl";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2200";
+						inherent_gain = "1";
+						mclk_multiplier = "2";
+						pix_clk_hz = "74250000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "120"; /* 12dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain = "0";
+						min_hdr_ratio = "16";
+						max_hdr_ratio = "16";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "30000000"; /* 30 */
+						step_framerate = "1";
+						default_framerate= "30000000";
+						exposure_factor = "1000000";
+						min_exp_time = "2433"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "33334";/* us */
+						embedded_metadata_height = "1";
+
+						/* WDR related settings */
+						num_control_point = "4";
+						control_point_x_0 = "0";
+						control_point_x_1 = "2048";
+						control_point_x_2 = "16384";
+						control_point_x_3 = "65536";
+						control_point_y_0 = "0";
+						control_point_y_1 = "2048";
+						control_point_y_2 = "2944";
+						control_point_y_3 = "3712";
+					};                    
+
+                    ports {
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+
+                        port@0 {
+                            reg = <0>;
+                            imx185_out0: endpoint {
+                                port-index = <0>;
+                                bus-width = <4>;
+                                remote-endpoint = <&csi_in0>;
+                            };
+                        };
+                    };
+                };
+                pca9570_a@24 {
+                    compatible = "nvidia,pca9570";
+                    reg = <0x24>;
+                    channel = "a";
+                    drive_ic= "DRV8838";
+                };
+
+
+
+            };
+            i2c@2 {
+                #address-cells = <1>;
+                #size-cells = <0>;
+                imx185_c@1a {
+                    compatible = "nvidia,imx185";
+                    reg = <0x1a>;
+                    devnode = "video1";
+
+                    /* Physical dimensions of sensor */
+                    physical_w = "15.0";
+					physical_h = "12.5";
+
+                    /* Define any required hw resources needed by driver */
+                    /* ie. clocks, io pins, power sources */
+                    clocks = <&tegra_car TEGRA186_CLK_EXTPERIPH2>,
+                         <&tegra_car TEGRA186_CLK_PLLP_OUT0>;
+                    clock-names = "extperiph2", "pllp_grtba";
+                    mclk = "extperiph2";
+                    reset-gpios = <&gpio_i2c_0_74 1 GPIO_ACTIVE_HIGH>;                   
+					post_crop_frame_drop = "0";
+                    use_decibel_gain = "true";
+
+                    mode0 {/*mode IMX185_MODE_1920X1080_CROP_30FPS*/
+						mclk_khz = "37125";
+						num_lanes = "4";
+						tegra_sinterface = "serial_c";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "12";
+						csi_pixel_bit_depth = "12";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2200";
+						inherent_gain = "1";
+						mclk_multiplier = "2";
+						pix_clk_hz = "74250000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "480"; /* 48dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain = "0";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "30000000"; /* 30 */
+						step_framerate = "1";
+						default_framerate = "30000000";
+						exposure_factor = "1000000";
+						min_exp_time = "30"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "33334";/* us */
+						embedded_metadata_height = "1";
+					};
+					mode1 {/*mode IMX185_MODE_1920X1080_CROP_10BIT_30FPS*/
+						mclk_khz = "37125";
+						num_lanes = "4";
+						tegra_sinterface = "serial_c";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "10";
+						csi_pixel_bit_depth = "10";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2640";
+						inherent_gain = "1";
+						mclk_multiplier = "2.4";
+						pix_clk_hz = "89100000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "480"; /* 48dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain ="0";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "30000000"; /* 30 */
+						step_framerate = "1";
+						default_framerate = "30000000";
+						exposure_factor = "1000000";
+						min_exp_time = "30"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "33334";/* us */
+						embedded_metadata_height = "1";
+					};
+
+					mode2 {/*mode IMX185_MODE_1920X1080_CROP_60FPS*/
+						mclk_khz = "37125";
+						num_lanes = "4";
+						tegra_sinterface = "serial_c";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "12";
+						csi_pixel_bit_depth = "12";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2200";
+						inherent_gain = "1";
+						mclk_multiplier = "4";
+						pix_clk_hz = "148500000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "480"; /* 48dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain = "0";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "60000000"; /* 60 */
+						step_framerate = "1";
+						default_framerate = "60000000";
+						exposure_factor = "1000000";
+						min_exp_time = "30"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "16667";/* us */
+						embedded_metadata_height = "1";
+					};
+
+					mode3 {/*mode IMX185_MODE_1920X1080_CROP_10BIT_60FPS*/
+						mclk_khz = "37125";
+						num_lanes = "4";
+						tegra_sinterface = "serial_c";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "10";
+						csi_pixel_bit_depth = "10";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2640";
+						inherent_gain = "1";
+						mclk_multiplier = "4.8";
+						pix_clk_hz = "178200000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "480"; /* 48dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain = "0";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "60000000"; /* 60 */
+						step_framerate = "1";
+						default_framerate = "60000000";
+						exposure_factor = "1000000";
+						min_exp_time = "30"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "16667";/* us */
+						embedded_metadata_height = "1";
+					};
+					mode4 {/*mode IMX185_MODE_1920X1080_CROP_HDR_30FPS*/
+						mclk_khz = "37125";
+						num_lanes = "4";
+						tegra_sinterface = "serial_c";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "16";
+						csi_pixel_bit_depth = "12";
+						mode_type = "bayer_wdr_pwl";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2200";
+						inherent_gain = "1";
+						mclk_multiplier = "2";
+						pix_clk_hz = "74250000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "120"; /* 12dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain = "0";
+						min_hdr_ratio = "16";
+						max_hdr_ratio = "16";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "30000000"; /* 30 */
+						step_framerate = "1";
+						default_framerate= "30000000";
+						exposure_factor = "1000000";
+						min_exp_time = "2433"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "33334";/* us */
+						embedded_metadata_height = "1";
+
+						/* WDR related settings */
+						num_control_point = "4";
+						control_point_x_0 = "0";
+						control_point_x_1 = "2048";
+						control_point_x_2 = "16384";
+						control_point_x_3 = "65536";
+						control_point_y_0 = "0";
+						control_point_y_1 = "2048";
+						control_point_y_2 = "2944";
+						control_point_y_3 = "3712";
+					};
+
+                    
+                    ports {
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+
+                        port@0 {
+                            reg = <0>;
+                            imx185_out2: endpoint {
+                                port-index = <2>;
+                                bus-width = <4>;
+                                remote-endpoint = <&csi_in1>;
+                            };
+                        };
+                    };
+                };
+
+                pca9570_b@24 {
+                    compatible = "nvidia,pca9570";
+                    reg = <0x24>;
+                    channel = "b";
+                    drive_ic= "DRV8838";
+                };
+
+
+            };
+        };
+	};
+   i2c@c240000 {
+        tca9546@71{
+            i2c@1 {
+                #address-cells = <1>;
+                #size-cells = <0>;
+                imx185_e@1a {
+                    compatible = "nvidia,imx185";
+                    reg = <0x1a>;
+                    devnode = "video2";
+                    /* Physical dimensions of sensor */
+
+                    physical_w = "15.0";
+					physical_h = "12.5";
+                    /* Define any required hw resources needed by driver */
+                    /* ie. clocks, io pins, power sources */
+                    clocks = <&tegra_car TEGRA186_CLK_EXTPERIPH1>,
+                             <&tegra_car TEGRA186_CLK_PLLP_OUT0>;
+                    clock-names = "extperiph1", "pllp_grtba";
+                    mclk = "extperiph1";
+                    reset-gpios = <&gpio_i2c_0_74 5 GPIO_ACTIVE_HIGH>;
+					post_crop_frame_drop = "0";
+                    use_decibel_gain = "true";
+                    
+
+                    mode0 {/*mode IMX185_MODE_1920X1080_CROP_30FPS*/
+						mclk_khz = "37125";
+						num_lanes = "4";
+						tegra_sinterface = "serial_e";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "12";
+						csi_pixel_bit_depth = "12";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2200";
+						inherent_gain = "1";
+						mclk_multiplier = "2";
+						pix_clk_hz = "74250000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "480"; /* 48dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain = "0";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "30000000"; /* 30 */
+						step_framerate = "1";
+						default_framerate = "30000000";
+						exposure_factor = "1000000";
+						min_exp_time = "30"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "33334";/* us */
+						embedded_metadata_height = "1";
+					};
+					mode1 {/*mode IMX185_MODE_1920X1080_CROP_10BIT_30FPS*/
+						mclk_khz = "37125";
+						num_lanes = "4";
+						tegra_sinterface = "serial_e";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "10";
+						csi_pixel_bit_depth = "10";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2640";
+						inherent_gain = "1";
+						mclk_multiplier = "2.4";
+						pix_clk_hz = "89100000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "480"; /* 48dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain ="0";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "30000000"; /* 30 */
+						step_framerate = "1";
+						default_framerate = "30000000";
+						exposure_factor = "1000000";
+						min_exp_time = "30"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "33334";/* us */
+						embedded_metadata_height = "1";
+					};
+
+					mode2 {/*mode IMX185_MODE_1920X1080_CROP_60FPS*/
+						mclk_khz = "37125";
+						num_lanes = "4";
+						tegra_sinterface = "serial_e";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "12";
+						csi_pixel_bit_depth = "12";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2200";
+						inherent_gain = "1";
+						mclk_multiplier = "4";
+						pix_clk_hz = "148500000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "480"; /* 48dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain = "0";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "60000000"; /* 60 */
+						step_framerate = "1";
+						default_framerate = "60000000";
+						exposure_factor = "1000000";
+						min_exp_time = "30"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "16667";/* us */
+						embedded_metadata_height = "1";
+					};
+
+					mode3 {/*mode IMX185_MODE_1920X1080_CROP_10BIT_60FPS*/
+						mclk_khz = "37125";
+						num_lanes = "4";
+						tegra_sinterface = "serial_e";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "10";
+						csi_pixel_bit_depth = "10";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2640";
+						inherent_gain = "1";
+						mclk_multiplier = "4.8";
+						pix_clk_hz = "178200000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "480"; /* 48dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain = "0";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "60000000"; /* 60 */
+						step_framerate = "1";
+						default_framerate = "60000000";
+						exposure_factor = "1000000";
+						min_exp_time = "30"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "16667";/* us */
+						embedded_metadata_height = "1";
+					};
+					mode4 {/*mode IMX185_MODE_1920X1080_CROP_HDR_30FPS*/
+						mclk_khz = "37125";
+						num_lanes = "4";
+						tegra_sinterface = "serial_e";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "16";
+						csi_pixel_bit_depth = "12";
+						mode_type = "bayer_wdr_pwl";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2200";
+						inherent_gain = "1";
+						mclk_multiplier = "2";
+						pix_clk_hz = "74250000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "120"; /* 12dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain = "0";
+						min_hdr_ratio = "16";
+						max_hdr_ratio = "16";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "30000000"; /* 30 */
+						step_framerate = "1";
+						default_framerate= "30000000";
+						exposure_factor = "1000000";
+						min_exp_time = "2433"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "33334";/* us */
+						embedded_metadata_height = "1";
+
+						/* WDR related settings */
+						num_control_point = "4";
+						control_point_x_0 = "0";
+						control_point_x_1 = "2048";
+						control_point_x_2 = "16384";
+						control_point_x_3 = "65536";
+						control_point_y_0 = "0";
+						control_point_y_1 = "2048";
+						control_point_y_2 = "2944";
+						control_point_y_3 = "3712";
+					};
+                    
+                    ports {
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+
+                        port@0 {
+                            reg = <0>;
+                            imx185_out4: endpoint {
+                                port-index = <4>;
+                                bus-width = <4>;
+                                remote-endpoint = <&csi_in2>;
+                            };
+                        };
+                    }; 
+                };
+                
+                pca9570_c@24 {
+                    compatible = "nvidia,pca9570";
+                    reg = <0x24>;
+                    channel = "c";
+                    drive_ic= "DRV8838";
+                };
+
+            };
+        };
+    };
+
+/**********************VI******************************************************************/
+
+     host1x {
+        vi@15700000 {
+            num-channels = <3>; //set number of channels
+            status = "okay";
+            ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+                port@0 {
+					reg = <0>;
+                    status = "okay";
+                    vi_in0: endpoint {
+                        status = "okay";
+                        port-index = <0>;
+                        bus-width = <4>;
+                        remote-endpoint = <&csi_out0>; 
+                    };
+                };
+
+                port@1 {
+					reg = <1>;
+                    status = "okay";
+                    vi_in1: endpoint {
+                        status = "okay";
+                        port-index = <2>;
+                        bus-width = <4>;
+                        remote-endpoint = <&csi_out1>; 
+                    };
+                };
+                port@2 {
+					reg = <2>;
+                    status = "okay";
+                    vi_in2: endpoint {
+                        status = "okay";
+                        port-index = <4>;
+                        bus-width = <4>;
+                        remote-endpoint = <&csi_out2>; 
+                    };
+                };
+            };
+        };
+
+/**********************CSI******************************************************************/
+        nvcsi@150c0000 {
+            num-channels = <3>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+            channel@0 {
+				reg = <0>;
+                status = "okay";
+                ports {
+					#address-cells = <1>;
+					#size-cells = <0>;
+                     port@0 {
+						reg = <0>;
+                        status = "okay";
+                        csi_in0: endpoint@0 {
+                            port-index = <0>;
+                            bus-width = <4>;
+                            remote-endpoint = <&imx185_out0>; //should be sensor port under i2c endpoint
+                            status = "okay";
+
+                        };
+                    };
+                    port@1 {
+						reg = <1>;
+                        status = "okay";
+                        csi_out0: endpoint@1 {
+                            status = "okay";
+                            remote-endpoint = <&vi_in0>; 
+                        };
+                    };
+                };
+            };
+
+            channel@1 {
+				reg = <1>;
+                status = "okay";
+                ports {
+					#address-cells = <1>;
+					#size-cells = <0>;
+                    port@0 {
+						reg = <0>;
+                        status = "okay";
+                        csi_in1: endpoint@2 {
+                            port-index = <2>;
+                            bus-width = <4>;
+                            remote-endpoint = <&imx185_out2>; //should be sensor port under i2c endpoint
+                            status = "okay";
+
+                        };
+                    };
+                    port@1 {
+						reg = <1>;
+                        status = "okay";
+                        csi_out1: endpoint@3 {
+                            status = "okay";
+                            remote-endpoint = <&vi_in1>; 
+                        };
+                    };
+                };
+            };
+            channel@2 {
+				reg = <2>;
+                status = "okay";				
+                ports {
+					#address-cells = <1>;
+					#size-cells = <0>;
+                    port@0 {
+						reg = <0>;
+                        status = "okay";
+                        csi_in2: endpoint@4 {
+                            port-index = <4>;
+                            bus-width = <4>;
+                            remote-endpoint = <&imx185_out4>; //should be sensor port under i2c endpoint
+                            status = "okay";
+                        };
+                    };
+                    port@1 {
+						reg = <1>;
+                        status = "okay";
+                        csi_out2: endpoint@5 {
+                            status = "okay";
+                            remote-endpoint = <&vi_in2>; 
+                        };
+                    };
+                };
+            };
+        };
+    };
+    lens_imx185@A6V26 {
+        min_focus_distance = "0.0";
+        hyper_focal = "0.0";
+        focal_length = "5.00";
+        f_number = "2.0";
+        aperture = "2.2";
+    };
+
+/**********************CAMERA PLATFORM*************************************************************/
+
+    tegra-camera-platform {
+        compatible = "nvidia, tegra-camera-platform";
+        /**
+        * Physical settings to calculate max ISO BW
+        *
+        * num_csi_lanes = <>;
+        * Total number of CSI lanes when all cameras are active
+        *
+        * max_lane_speed = <>;
+        * Max lane speed in Kbit/s
+        *
+        * min_bits_per_pixel = <>;
+        * Min bits per pixel
+        *
+        * vi_peak_byte_per_pixel = <>;
+        * Max byte per pixel for the VI ISO case
+        *
+        * vi_bw_margin_pct = <>;
+        * Vi bandwidth margin in percentage
+        *
+        * max_pixel_rate = <>;
+        * Max pixel rate in Kpixel/s for the ISP ISO case
+        * Set this to the highest pix_clk_hz out of all available modes.
+        *
+        * isp_peak_byte_per_pixel = <>;
+        * Max byte per pixel for the ISP ISO case
+        *
+        * isp_bw_margin_pct = <>;
+        * Isp bandwidth margin in percentage
+        */
+        num_csi_lanes = <12>;
+        max_lane_speed = <1500000>;
+        min_bits_per_pixel = <10>;
+        vi_peak_byte_per_pixel = <2>;
+        vi_bw_margin_pct = <25>;
+        max_pixel_rate = <750000>;
+        isp_peak_byte_per_pixel = <5>;
+        isp_bw_margin_pct = <25>;
+
+        /**
+        * The general guideline for naming badge_info contains 3 parts, and is as follows,
+        * The first part is the camera_board_id for the module; if the module is in a FFD
+        * platform, then use the platform name for this part.
+        * The second part contains the position of the module, ex. “rear” or “front”.
+        * The third part contains the last 6 characters of a part number which is found
+        * in the module's specsheet from the vender.
+        */
+        modules {
+
+            module0 {
+                badge = "imx185_bottom_A6V26";
+                position = "bottom";
+                orientation = "0";
+                status = "okay";
+                drivernode0 {
+                    status = "okay";
+                    pcl_id = "v4l2_sensor";
+                    devname = "imx185 30-001a";
+                    proc-device-tree = "/proc/device-tree/i2c@3180000/tca9546@70/i2c@0/imx185_a@1a";
+                };
+                drivernode1 {
+                    status = "okay";
+                    pcl_id = "v4l2_lens";
+                    proc-device-tree = "/proc/device-tree/lens_imx185@A6V26/";
+                };
+            };
+
+            module1 {
+                badge = "imx185_top_A6V26";
+                position = "top";
+                orientation = "0";
+                status = "okay";
+                drivernode0 {
+                status = "okay";
+                    pcl_id = "v4l2_sensor";
+                    devname = "imx185 32-001a";
+                    proc-device-tree = "/proc/device-tree/i2c@3180000/tca9546@70/i2c@2/imx185_c@1a";
+                };
+                drivernode1 {
+                status = "okay";
+                    pcl_id = "v4l2_lens";
+                    proc-device-tree = "/proc/device-tree/lens_imx185@A6V26/";
+                };
+            };
+
+            module2 {
+                badge = "imx185_center_A6V26";
+                position = "center";
+                orientation = "0";
+                status = "okay";
+                drivernode0 {
+                status = "okay";
+                    pcl_id = "v4l2_sensor";
+                    devname = "imx185 35-001a";
+                    proc-device-tree = "/proc/device-tree/i2c@c240000/tca9546@71/i2c@1/imx185_e@1a";
+                };
+                drivernode1 {
+                status = "okay";
+                    pcl_id = "v4l2_lens";
+                    proc-device-tree = "/proc/device-tree/lens_imx185@A6V26/";
+                };
+            };
+        };
+    };
+};
+

--- a/nvidia/platform/t18x/quill/kernel-dts/tegra186-tx2-cti-ASG006-IMX185-6CAM.dts
+++ b/nvidia/platform/t18x/quill/kernel-dts/tegra186-tx2-cti-ASG006-IMX185-6CAM.dts
@@ -1,0 +1,2003 @@
+#include <tegra186-tx2-cti-ASG006-base.dts>
+#include <t18x-common-platforms/tegra186-tx2-cti-camera-base.dtsi>
+#include "dt-bindings/clock/tegra186-clock.h"
+
+
+/* camera control gpio definitions */
+
+#define CAM0_RST_L  TEGRA_MAIN_GPIO(R, 5)
+#define CAM0_PWDN   TEGRA_MAIN_GPIO(R, 0)
+#define CAM1_RST_L  TEGRA_MAIN_GPIO(R, 1)
+#define CAM1_PWDN   TEGRA_MAIN_GPIO(N, 2)
+
+
+/ {
+    
+    gpio@2200000 {
+        camera-control-output-low {
+            gpio-hog;
+            output-low;
+            gpios = <CAM0_RST_L 0 CAM0_PWDN 0
+                 CAM1_RST_L 0 CAM1_PWDN 0>;
+            label = "cam0-rst", "cam0-pwdn",
+                "cam1-rst", "cam1-pwdn";
+        };
+    };
+
+
+/**********************SENSORS******************************************************************/
+
+	i2c@3180000 {       //set this to correct i2c bus 
+        tca9546@70{    
+            i2c@0{  //cam_i2c/Mux@70/I2C_A
+                #address-cells = <1>;
+                #size-cells = <0>;
+
+                imx185_a@1a {
+                    compatible = "nvidia,imx185";
+                    reg = <0x1a>;
+                    devnode = "video0";
+
+                    /* Physical dimensions of sensor */
+                    physical_w = "15.0";
+                    physical_h = "12.5";
+                    clocks = <&tegra_car TEGRA186_CLK_EXTPERIPH1>,
+                             <&tegra_car TEGRA186_CLK_PLLP_OUT0>;
+                    clock-names = "extperiph1", "pllp_grtba";
+                    mclk = "extperiph1";
+                    sensor_model = "imx185";
+                    delayed_gain = "true";
+                    reset-gpios = <&tegra_main_gpio CAM0_RST_L GPIO_ACTIVE_HIGH>;
+                    post_crop_frame_drop = "0";
+                    use_decibel_gain = "true";
+
+                    mode0 {/*mode IMX185_MODE_1920X1080_CROP_30FPS*/
+						mclk_khz = "37125";
+						num_lanes = "2";
+						tegra_sinterface = "serial_a";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "12";
+						csi_pixel_bit_depth = "12";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2200";
+						inherent_gain = "1";
+						mclk_multiplier = "2";
+						pix_clk_hz = "74250000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "480"; /* 48dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain = "0";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "30000000"; /* 30 */
+						step_framerate = "1";
+						default_framerate = "30000000";
+						exposure_factor = "1000000";
+						min_exp_time = "30"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "33334";/* us */
+						embedded_metadata_height = "1";
+					};
+					mode1 {/*mode IMX185_MODE_1920X1080_CROP_10BIT_30FPS*/
+						mclk_khz = "37125";
+						num_lanes = "2";
+						tegra_sinterface = "serial_a";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "10";
+						csi_pixel_bit_depth = "10";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2640";
+						inherent_gain = "1";
+						mclk_multiplier = "2.4";
+						pix_clk_hz = "89100000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "480"; /* 48dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain ="0";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "30000000"; /* 30 */
+						step_framerate = "1";
+						default_framerate = "30000000";
+						exposure_factor = "1000000";
+						min_exp_time = "30"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "33334";/* us */
+						embedded_metadata_height = "1";
+					};
+
+					mode2 {/*mode IMX185_MODE_1920X1080_CROP_60FPS*/
+						mclk_khz = "37125";
+						num_lanes = "2";
+						tegra_sinterface = "serial_a";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "12";
+						csi_pixel_bit_depth = "12";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2200";
+						inherent_gain = "1";
+						mclk_multiplier = "4";
+						pix_clk_hz = "148500000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "480"; /* 48dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain = "0";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "60000000"; /* 60 */
+						step_framerate = "1";
+						default_framerate = "60000000";
+						exposure_factor = "1000000";
+						min_exp_time = "30"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "16667";/* us */
+						embedded_metadata_height = "1";
+					};
+
+					mode3 {/*mode IMX185_MODE_1920X1080_CROP_10BIT_60FPS*/
+						mclk_khz = "37125";
+						num_lanes = "2";
+						tegra_sinterface = "serial_a";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "10";
+						csi_pixel_bit_depth = "10";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2640";
+						inherent_gain = "1";
+						mclk_multiplier = "4.8";
+						pix_clk_hz = "178200000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "480"; /* 48dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain = "0";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "60000000"; /* 60 */
+						step_framerate = "1";
+						default_framerate = "60000000";
+						exposure_factor = "1000000";
+						min_exp_time = "30"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "16667";/* us */
+						embedded_metadata_height = "1";
+					};
+					mode4 {/*mode IMX185_MODE_1920X1080_CROP_HDR_30FPS*/
+						mclk_khz = "37125";
+						num_lanes = "2";
+						tegra_sinterface = "serial_a";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "16";
+						csi_pixel_bit_depth = "12";
+						mode_type = "bayer_wdr_pwl";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2200";
+						inherent_gain = "1";
+						mclk_multiplier = "2";
+						pix_clk_hz = "74250000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "120"; /* 12dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain = "0";
+						min_hdr_ratio = "16";
+						max_hdr_ratio = "16";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "30000000"; /* 30 */
+						step_framerate = "1";
+						default_framerate= "30000000";
+						exposure_factor = "1000000";
+						min_exp_time = "2433"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "33334";/* us */
+						embedded_metadata_height = "1";
+
+						/* WDR related settings */
+						num_control_point = "4";
+						control_point_x_0 = "0";
+						control_point_x_1 = "2048";
+						control_point_x_2 = "16384";
+						control_point_x_3 = "65536";
+						control_point_y_0 = "0";
+						control_point_y_1 = "2048";
+						control_point_y_2 = "2944";
+						control_point_y_3 = "3712";
+					};
+                    
+
+                    ports {
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+
+                        port@0 {
+                            reg = <0>;
+                            imx185_out0: endpoint {
+                                port-index = <0>;
+                                bus-width = <2>;
+                                remote-endpoint = <&csi_in0>;
+                            };
+                        };
+                    };
+                };
+
+                pca9570_a@24 {
+                    compatible = "nvidia,pca9570";
+                    reg = <0x24>;
+                    channel = "a";
+                    drive_ic= "DRV8838";
+                   };
+
+            };
+
+
+            i2c@1{  //cam_i2c/Mux@70/I2C_B
+                #address-cells = <1>;
+                #size-cells = <0>;
+
+                imx185_b@1a {
+                    compatible = "nvidia,imx185";
+                    reg = <0x1a>;
+                    devnode = "video1";
+
+                    /* Physical dimensions of sensor */
+                    physical_w = "15.0";
+                    physical_h = "12.5";
+                    clocks = <&tegra_car TEGRA186_CLK_EXTPERIPH1>,
+                             <&tegra_car TEGRA186_CLK_PLLP_OUT0>;
+                    clock-names = "extperiph1", "pllp_grtba";
+                    mclk = "extperiph1";
+                    sensor_model = "imx185";
+                    delayed_gain = "true";
+                    reset-gpios = <&tegra_main_gpio CAM1_RST_L GPIO_ACTIVE_HIGH>;
+                    post_crop_frame_drop = "0";
+                    use_decibel_gain = "true";
+
+                    mode0 {/*mode IMX185_MODE_1920X1080_CROP_30FPS*/
+						mclk_khz = "37125";
+						num_lanes = "2";
+						tegra_sinterface = "serial_b";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "12";
+						csi_pixel_bit_depth = "12";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2200";
+						inherent_gain = "1";
+						mclk_multiplier = "2";
+						pix_clk_hz = "74250000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "480"; /* 48dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain = "0";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "30000000"; /* 30 */
+						step_framerate = "1";
+						default_framerate = "30000000";
+						exposure_factor = "1000000";
+						min_exp_time = "30"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "33334";/* us */
+						embedded_metadata_height = "1";
+					};
+					mode1 {/*mode IMX185_MODE_1920X1080_CROP_10BIT_30FPS*/
+						mclk_khz = "37125";
+						num_lanes = "2";
+						tegra_sinterface = "serial_b";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "10";
+						csi_pixel_bit_depth = "10";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2640";
+						inherent_gain = "1";
+						mclk_multiplier = "2.4";
+						pix_clk_hz = "89100000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "480"; /* 48dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain ="0";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "30000000"; /* 30 */
+						step_framerate = "1";
+						default_framerate = "30000000";
+						exposure_factor = "1000000";
+						min_exp_time = "30"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "33334";/* us */
+						embedded_metadata_height = "1";
+					};
+
+					mode2 {/*mode IMX185_MODE_1920X1080_CROP_60FPS*/
+						mclk_khz = "37125";
+						num_lanes = "2";
+						tegra_sinterface = "serial_b";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "12";
+						csi_pixel_bit_depth = "12";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2200";
+						inherent_gain = "1";
+						mclk_multiplier = "4";
+						pix_clk_hz = "148500000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "480"; /* 48dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain = "0";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "60000000"; /* 60 */
+						step_framerate = "1";
+						default_framerate = "60000000";
+						exposure_factor = "1000000";
+						min_exp_time = "30"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "16667";/* us */
+						embedded_metadata_height = "1";
+					};
+
+					mode3 {/*mode IMX185_MODE_1920X1080_CROP_10BIT_60FPS*/
+						mclk_khz = "37125";
+						num_lanes = "2";
+						tegra_sinterface = "serial_b";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "10";
+						csi_pixel_bit_depth = "10";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2640";
+						inherent_gain = "1";
+						mclk_multiplier = "4.8";
+						pix_clk_hz = "178200000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "480"; /* 48dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain = "0";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "60000000"; /* 60 */
+						step_framerate = "1";
+						default_framerate = "60000000";
+						exposure_factor = "1000000";
+						min_exp_time = "30"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "16667";/* us */
+						embedded_metadata_height = "1";
+					};
+					mode4 {/*mode IMX185_MODE_1920X1080_CROP_HDR_30FPS*/
+						mclk_khz = "37125";
+						num_lanes = "2";
+						tegra_sinterface = "serial_b";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "16";
+						csi_pixel_bit_depth = "12";
+						mode_type = "bayer_wdr_pwl";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2200";
+						inherent_gain = "1";
+						mclk_multiplier = "2";
+						pix_clk_hz = "74250000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "120"; /* 12dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain = "0";
+						min_hdr_ratio = "16";
+						max_hdr_ratio = "16";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "30000000"; /* 30 */
+						step_framerate = "1";
+						default_framerate= "30000000";
+						exposure_factor = "1000000";
+						min_exp_time = "2433"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "33334";/* us */
+						embedded_metadata_height = "1";
+
+						/* WDR related settings */
+						num_control_point = "4";
+						control_point_x_0 = "0";
+						control_point_x_1 = "2048";
+						control_point_x_2 = "16384";
+						control_point_x_3 = "65536";
+						control_point_y_0 = "0";
+						control_point_y_1 = "2048";
+						control_point_y_2 = "2944";
+						control_point_y_3 = "3712";
+					};
+                    
+
+
+                    ports {
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+
+                        port@0 {
+                            reg = <0>;
+                            imx185_out1: endpoint {
+                                port-index = <1>;
+                                bus-width = <2>;
+                                remote-endpoint = <&csi_in1>;
+                            };
+                        };
+                    };
+                };
+
+                pca9570_b@24 {
+                    compatible = "nvidia,pca9570";
+                    reg = <0x24>;
+                    channel = "b";
+                    drive_ic= "DRV8838";
+                   };
+
+            };
+
+
+            i2c@2 { //cam_i2c/Mux@70/I2C_C
+                #address-cells = <1>;
+                #size-cells = <0>;
+                imx185_c@1a {
+                    compatible = "nvidia,imx185";
+                    reg = <0x1a>;
+                    devnode = "video2";
+
+                    /* Physical dimensions of sensor */
+                    physical_w = "15.0";
+                    physical_h = "12.5";
+
+                    /* Define any required hw resources needed by driver */
+                    /* ie. clocks, io pins, power sources */
+                    clocks = <&tegra_car TEGRA186_CLK_EXTPERIPH2>,
+                         <&tegra_car TEGRA186_CLK_PLLP_OUT0>;
+                    clock-names = "extperiph2", "pllp_grtba";
+                    mclk = "extperiph2";
+                    reset-gpios = <&gpio_i2c_0_74 1 GPIO_ACTIVE_HIGH>;
+                    post_crop_frame_drop = "0";
+                    use_decibel_gain = "true";
+
+                    mode0 {/*mode IMX185_MODE_1920X1080_CROP_30FPS*/
+						mclk_khz = "37125";
+						num_lanes = "2";
+						tegra_sinterface = "serial_c";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "12";
+						csi_pixel_bit_depth = "12";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2200";
+						inherent_gain = "1";
+						mclk_multiplier = "2";
+						pix_clk_hz = "74250000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "480"; /* 48dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain = "0";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "30000000"; /* 30 */
+						step_framerate = "1";
+						default_framerate = "30000000";
+						exposure_factor = "1000000";
+						min_exp_time = "30"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "33334";/* us */
+						embedded_metadata_height = "1";
+					};
+					mode1 {/*mode IMX185_MODE_1920X1080_CROP_10BIT_30FPS*/
+						mclk_khz = "37125";
+						num_lanes = "2";
+						tegra_sinterface = "serial_c";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "10";
+						csi_pixel_bit_depth = "10";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2640";
+						inherent_gain = "1";
+						mclk_multiplier = "2.4";
+						pix_clk_hz = "89100000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "480"; /* 48dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain ="0";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "30000000"; /* 30 */
+						step_framerate = "1";
+						default_framerate = "30000000";
+						exposure_factor = "1000000";
+						min_exp_time = "30"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "33334";/* us */
+						embedded_metadata_height = "1";
+					};
+
+					mode2 {/*mode IMX185_MODE_1920X1080_CROP_60FPS*/
+						mclk_khz = "37125";
+						num_lanes = "2";
+						tegra_sinterface = "serial_c";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "12";
+						csi_pixel_bit_depth = "12";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2200";
+						inherent_gain = "1";
+						mclk_multiplier = "4";
+						pix_clk_hz = "148500000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "480"; /* 48dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain = "0";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "60000000"; /* 60 */
+						step_framerate = "1";
+						default_framerate = "60000000";
+						exposure_factor = "1000000";
+						min_exp_time = "30"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "16667";/* us */
+						embedded_metadata_height = "1";
+					};
+
+					mode3 {/*mode IMX185_MODE_1920X1080_CROP_10BIT_60FPS*/
+						mclk_khz = "37125";
+						num_lanes = "2";
+						tegra_sinterface = "serial_c";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "10";
+						csi_pixel_bit_depth = "10";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2640";
+						inherent_gain = "1";
+						mclk_multiplier = "4.8";
+						pix_clk_hz = "178200000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "480"; /* 48dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain = "0";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "60000000"; /* 60 */
+						step_framerate = "1";
+						default_framerate = "60000000";
+						exposure_factor = "1000000";
+						min_exp_time = "30"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "16667";/* us */
+						embedded_metadata_height = "1";
+					};
+					mode4 {/*mode IMX185_MODE_1920X1080_CROP_HDR_30FPS*/
+						mclk_khz = "37125";
+						num_lanes = "2";
+						tegra_sinterface = "serial_c";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "16";
+						csi_pixel_bit_depth = "12";
+						mode_type = "bayer_wdr_pwl";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2200";
+						inherent_gain = "1";
+						mclk_multiplier = "2";
+						pix_clk_hz = "74250000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "120"; /* 12dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain = "0";
+						min_hdr_ratio = "16";
+						max_hdr_ratio = "16";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "30000000"; /* 30 */
+						step_framerate = "1";
+						default_framerate= "30000000";
+						exposure_factor = "1000000";
+						min_exp_time = "2433"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "33334";/* us */
+						embedded_metadata_height = "1";
+
+						/* WDR related settings */
+						num_control_point = "4";
+						control_point_x_0 = "0";
+						control_point_x_1 = "2048";
+						control_point_x_2 = "16384";
+						control_point_x_3 = "65536";
+						control_point_y_0 = "0";
+						control_point_y_1 = "2048";
+						control_point_y_2 = "2944";
+						control_point_y_3 = "3712";
+					};                    
+
+                    ports {
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+
+                        port@0 {
+                            reg = <0>;
+                            imx185_out2: endpoint {
+                                port-index = <2>;
+                                bus-width = <2>;
+                                remote-endpoint = <&csi_in2>;
+                            };
+                        };
+                    };
+                };
+
+                pca9570_c@24 {
+                    compatible = "nvidia,pca9570";
+                    reg = <0x24>;
+                    channel = "c";
+                    drive_ic= "DRV8838";
+                   };
+
+            };
+        };
+	};
+
+    i2c@c240000 {
+        tca9546@71{
+            i2c@0 { //gen_i2c_0/Mux@71/I2C_D
+                #address-cells = <1>;
+                #size-cells = <0>;
+                imx185_d@1a {
+                    compatible = "nvidia,imx185";
+                    reg = <0x1a>;
+                    devnode = "video3";
+                    /* Physical dimensions of sensor */
+
+                    physical_w = "15.0";
+                    physical_h = "12.5";
+                    /* Define any required hw resources needed by driver */
+                    /* ie. clocks, io pins, power sources */
+                    clocks = <&tegra_car TEGRA186_CLK_EXTPERIPH2>,
+                             <&tegra_car TEGRA186_CLK_PLLP_OUT0>;
+                    clock-names = "extperiph2", "pllp_grtba";
+                    mclk = "extperiph2";
+                    reset-gpios = <&gpio_i2c_0_74 3 GPIO_ACTIVE_HIGH>;
+                    post_crop_frame_drop = "0";
+                    use_decibel_gain = "true";
+					
+                    mode0 {/*mode IMX185_MODE_1920X1080_CROP_30FPS*/
+						mclk_khz = "37125";
+						num_lanes = "2";
+						tegra_sinterface = "serial_d";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "12";
+						csi_pixel_bit_depth = "12";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2200";
+						inherent_gain = "1";
+						mclk_multiplier = "2";
+						pix_clk_hz = "74250000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "480"; /* 48dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain = "0";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "30000000"; /* 30 */
+						step_framerate = "1";
+						default_framerate = "30000000";
+						exposure_factor = "1000000";
+						min_exp_time = "30"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "33334";/* us */
+						embedded_metadata_height = "1";
+					};
+					mode1 {/*mode IMX185_MODE_1920X1080_CROP_10BIT_30FPS*/
+						mclk_khz = "37125";
+						num_lanes = "2";
+						tegra_sinterface = "serial_d";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "10";
+						csi_pixel_bit_depth = "10";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2640";
+						inherent_gain = "1";
+						mclk_multiplier = "2.4";
+						pix_clk_hz = "89100000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "480"; /* 48dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain ="0";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "30000000"; /* 30 */
+						step_framerate = "1";
+						default_framerate = "30000000";
+						exposure_factor = "1000000";
+						min_exp_time = "30"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "33334";/* us */
+						embedded_metadata_height = "1";
+					};
+
+					mode2 {/*mode IMX185_MODE_1920X1080_CROP_60FPS*/
+						mclk_khz = "37125";
+						num_lanes = "2";
+						tegra_sinterface = "serial_d";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "12";
+						csi_pixel_bit_depth = "12";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2200";
+						inherent_gain = "1";
+						mclk_multiplier = "4";
+						pix_clk_hz = "148500000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "480"; /* 48dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain = "0";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "60000000"; /* 60 */
+						step_framerate = "1";
+						default_framerate = "60000000";
+						exposure_factor = "1000000";
+						min_exp_time = "30"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "16667";/* us */
+						embedded_metadata_height = "1";
+					};
+
+					mode3 {/*mode IMX185_MODE_1920X1080_CROP_10BIT_60FPS*/
+						mclk_khz = "37125";
+						num_lanes = "2";
+						tegra_sinterface = "serial_d";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "10";
+						csi_pixel_bit_depth = "10";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2640";
+						inherent_gain = "1";
+						mclk_multiplier = "4.8";
+						pix_clk_hz = "178200000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "480"; /* 48dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain = "0";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "60000000"; /* 60 */
+						step_framerate = "1";
+						default_framerate = "60000000";
+						exposure_factor = "1000000";
+						min_exp_time = "30"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "16667";/* us */
+						embedded_metadata_height = "1";
+					};
+					mode4 {/*mode IMX185_MODE_1920X1080_CROP_HDR_30FPS*/
+						mclk_khz = "37125";
+						num_lanes = "2";
+						tegra_sinterface = "serial_d";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "16";
+						csi_pixel_bit_depth = "12";
+						mode_type = "bayer_wdr_pwl";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2200";
+						inherent_gain = "1";
+						mclk_multiplier = "2";
+						pix_clk_hz = "74250000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "120"; /* 12dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain = "0";
+						min_hdr_ratio = "16";
+						max_hdr_ratio = "16";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "30000000"; /* 30 */
+						step_framerate = "1";
+						default_framerate= "30000000";
+						exposure_factor = "1000000";
+						min_exp_time = "2433"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "33334";/* us */
+						embedded_metadata_height = "1";
+
+						/* WDR related settings */
+						num_control_point = "4";
+						control_point_x_0 = "0";
+						control_point_x_1 = "2048";
+						control_point_x_2 = "16384";
+						control_point_x_3 = "65536";
+						control_point_y_0 = "0";
+						control_point_y_1 = "2048";
+						control_point_y_2 = "2944";
+						control_point_y_3 = "3712";
+					};
+
+                    
+                    ports {
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+
+                        port@0 {
+                            reg = <0>;
+                            imx185_out3: endpoint {
+                                port-index = <3>;
+                                bus-width = <2>;
+                                remote-endpoint = <&csi_in3>;
+                            };
+                        };
+                    }; 
+                };
+                pca9570_d@24 {
+                    compatible = "nvidia,pca9570";
+                    reg = <0x24>;
+                    channel = "d";
+                    drive_ic= "DRV8838";
+                   };
+            };
+
+            i2c@1 { //gen_i2c_0/Mux@71/I2C_E
+                #address-cells = <1>;
+                #size-cells = <0>;
+                imx185_e@1a {
+                    compatible = "nvidia,imx185";
+                    reg = <0x1a>;
+                    devnode = "video4";
+                    /* Physical dimensions of sensor */
+
+                    physical_w = "15.0";
+                    physical_h = "12.5";
+                    /* Define any required hw resources needed by driver */
+                    /* ie. clocks, io pins, power sources */
+                    clocks = <&tegra_car TEGRA186_CLK_EXTPERIPH1>,
+                             <&tegra_car TEGRA186_CLK_PLLP_OUT0>;
+                    clock-names = "extperiph1", "pllp_grtba";
+                    mclk = "extperiph1";
+                    reset-gpios = <&gpio_i2c_0_74 5 GPIO_ACTIVE_HIGH>;
+                    post_crop_frame_drop = "0";
+                    use_decibel_gain = "true";
+
+                    mode0 {/*mode IMX185_MODE_1920X1080_CROP_30FPS*/
+						mclk_khz = "37125";
+						num_lanes = "2";
+						tegra_sinterface = "serial_e";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "12";
+						csi_pixel_bit_depth = "12";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2200";
+						inherent_gain = "1";
+						mclk_multiplier = "2";
+						pix_clk_hz = "74250000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "480"; /* 48dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain = "0";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "30000000"; /* 30 */
+						step_framerate = "1";
+						default_framerate = "30000000";
+						exposure_factor = "1000000";
+						min_exp_time = "30"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "33334";/* us */
+						embedded_metadata_height = "1";
+					};
+					mode1 {/*mode IMX185_MODE_1920X1080_CROP_10BIT_30FPS*/
+						mclk_khz = "37125";
+						num_lanes = "2";
+						tegra_sinterface = "serial_e";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "10";
+						csi_pixel_bit_depth = "10";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2640";
+						inherent_gain = "1";
+						mclk_multiplier = "2.4";
+						pix_clk_hz = "89100000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "480"; /* 48dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain ="0";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "30000000"; /* 30 */
+						step_framerate = "1";
+						default_framerate = "30000000";
+						exposure_factor = "1000000";
+						min_exp_time = "30"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "33334";/* us */
+						embedded_metadata_height = "1";
+					};
+
+					mode2 {/*mode IMX185_MODE_1920X1080_CROP_60FPS*/
+						mclk_khz = "37125";
+						num_lanes = "2";
+						tegra_sinterface = "serial_e";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "12";
+						csi_pixel_bit_depth = "12";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2200";
+						inherent_gain = "1";
+						mclk_multiplier = "4";
+						pix_clk_hz = "148500000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "480"; /* 48dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain = "0";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "60000000"; /* 60 */
+						step_framerate = "1";
+						default_framerate = "60000000";
+						exposure_factor = "1000000";
+						min_exp_time = "30"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "16667";/* us */
+						embedded_metadata_height = "1";
+					};
+
+					mode3 {/*mode IMX185_MODE_1920X1080_CROP_10BIT_60FPS*/
+						mclk_khz = "37125";
+						num_lanes = "2";
+						tegra_sinterface = "serial_e";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "10";
+						csi_pixel_bit_depth = "10";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2640";
+						inherent_gain = "1";
+						mclk_multiplier = "4.8";
+						pix_clk_hz = "178200000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "480"; /* 48dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain = "0";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "60000000"; /* 60 */
+						step_framerate = "1";
+						default_framerate = "60000000";
+						exposure_factor = "1000000";
+						min_exp_time = "30"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "16667";/* us */
+						embedded_metadata_height = "1";
+					};
+					mode4 {/*mode IMX185_MODE_1920X1080_CROP_HDR_30FPS*/
+						mclk_khz = "37125";
+						num_lanes = "2";
+						tegra_sinterface = "serial_e";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "16";
+						csi_pixel_bit_depth = "12";
+						mode_type = "bayer_wdr_pwl";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2200";
+						inherent_gain = "1";
+						mclk_multiplier = "2";
+						pix_clk_hz = "74250000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "120"; /* 12dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain = "0";
+						min_hdr_ratio = "16";
+						max_hdr_ratio = "16";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "30000000"; /* 30 */
+						step_framerate = "1";
+						default_framerate= "30000000";
+						exposure_factor = "1000000";
+						min_exp_time = "2433"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "33334";/* us */
+						embedded_metadata_height = "1";
+
+						/* WDR related settings */
+						num_control_point = "4";
+						control_point_x_0 = "0";
+						control_point_x_1 = "2048";
+						control_point_x_2 = "16384";
+						control_point_x_3 = "65536";
+						control_point_y_0 = "0";
+						control_point_y_1 = "2048";
+						control_point_y_2 = "2944";
+						control_point_y_3 = "3712";
+					};
+                    
+                    ports {
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+
+                        port@0 {
+                            reg = <0>;
+                            imx185_out4: endpoint {
+                                port-index = <4>;
+                                bus-width = <2>;
+                                remote-endpoint = <&csi_in4>;
+                            };
+                        };
+                    }; 
+                };
+
+                pca9570_e@24 {
+                    compatible = "nvidia,pca9570";
+                    reg = <0x24>;
+                    channel = "e";
+                    drive_ic= "DRV8838";
+                   };
+            };
+
+            i2c@2 { //gen_i2c_0/Mux@71/I2C_F
+                #address-cells = <1>;
+                #size-cells = <0>;
+                imx185_f@1a {
+                    compatible = "nvidia,imx185";
+                    reg = <0x1a>;
+                    devnode = "video5";
+                    /* Physical dimensions of sensor */
+
+                    physical_w = "15.0";
+                    physical_h = "12.5";
+                    /* Define any required hw resources needed by driver */
+                    /* ie. clocks, io pins, power sources */
+                    clocks = <&tegra_car TEGRA186_CLK_EXTPERIPH2>,
+                             <&tegra_car TEGRA186_CLK_PLLP_OUT0>;
+                    clock-names = "extperiph2", "pllp_grtba";
+                    mclk = "extperiph2";
+                    reset-gpios = <&gpio_i2c_0_74 7 GPIO_ACTIVE_HIGH>;
+                    post_crop_frame_drop = "0";
+                    use_decibel_gain = "true";
+					
+                    mode0 {/*mode IMX185_MODE_1920X1080_CROP_30FPS*/
+						mclk_khz = "37125";
+						num_lanes = "2";
+						tegra_sinterface = "serial_f";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "12";
+						csi_pixel_bit_depth = "12";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2200";
+						inherent_gain = "1";
+						mclk_multiplier = "2";
+						pix_clk_hz = "74250000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "480"; /* 48dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain = "0";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "30000000"; /* 30 */
+						step_framerate = "1";
+						default_framerate = "30000000";
+						exposure_factor = "1000000";
+						min_exp_time = "30"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "33334";/* us */
+						embedded_metadata_height = "1";
+					};
+					mode1 {/*mode IMX185_MODE_1920X1080_CROP_10BIT_30FPS*/
+						mclk_khz = "37125";
+						num_lanes = "2";
+						tegra_sinterface = "serial_f";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "10";
+						csi_pixel_bit_depth = "10";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2640";
+						inherent_gain = "1";
+						mclk_multiplier = "2.4";
+						pix_clk_hz = "89100000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "480"; /* 48dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain ="0";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "30000000"; /* 30 */
+						step_framerate = "1";
+						default_framerate = "30000000";
+						exposure_factor = "1000000";
+						min_exp_time = "30"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "33334";/* us */
+						embedded_metadata_height = "1";
+					};
+
+					mode2 {/*mode IMX185_MODE_1920X1080_CROP_60FPS*/
+						mclk_khz = "37125";
+						num_lanes = "2";
+						tegra_sinterface = "serial_f";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "12";
+						csi_pixel_bit_depth = "12";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2200";
+						inherent_gain = "1";
+						mclk_multiplier = "4";
+						pix_clk_hz = "148500000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "480"; /* 48dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain = "0";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "60000000"; /* 60 */
+						step_framerate = "1";
+						default_framerate = "60000000";
+						exposure_factor = "1000000";
+						min_exp_time = "30"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "16667";/* us */
+						embedded_metadata_height = "1";
+					};
+
+					mode3 {/*mode IMX185_MODE_1920X1080_CROP_10BIT_60FPS*/
+						mclk_khz = "37125";
+						num_lanes = "2";
+						tegra_sinterface = "serial_f";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "10";
+						csi_pixel_bit_depth = "10";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2640";
+						inherent_gain = "1";
+						mclk_multiplier = "4.8";
+						pix_clk_hz = "178200000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "480"; /* 48dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain = "0";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "60000000"; /* 60 */
+						step_framerate = "1";
+						default_framerate = "60000000";
+						exposure_factor = "1000000";
+						min_exp_time = "30"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "16667";/* us */
+						embedded_metadata_height = "1";
+					};
+					mode4 {/*mode IMX185_MODE_1920X1080_CROP_HDR_30FPS*/
+						mclk_khz = "37125";
+						num_lanes = "2";
+						tegra_sinterface = "serial_f";
+						phy_mode = "DPHY";
+						discontinuous_clk = "no";
+						dpcm_enable = "false";
+						cil_settletime = "0";
+						dynamic_pixel_bit_depth = "16";
+						csi_pixel_bit_depth = "12";
+						mode_type = "bayer_wdr_pwl";
+						pixel_phase = "rggb";
+
+						active_w = "1920";
+						active_h = "1080";
+						readout_orientation = "0";
+						line_length = "2200";
+						inherent_gain = "1";
+						mclk_multiplier = "2";
+						pix_clk_hz = "74250000";
+
+						gain_factor = "10";
+						min_gain_val = "0"; /* 0dB */
+						max_gain_val = "120"; /* 12dB */
+						step_gain_val = "3"; /* 0.3 */
+						default_gain = "0";
+						min_hdr_ratio = "16";
+						max_hdr_ratio = "16";
+						framerate_factor = "1000000";
+						min_framerate = "1500000"; /* 1.5 */
+						max_framerate = "30000000"; /* 30 */
+						step_framerate = "1";
+						default_framerate= "30000000";
+						exposure_factor = "1000000";
+						min_exp_time = "2433"; /* us */
+						max_exp_time = "660000"; /* us */
+						step_exp_time = "1";
+						default_exp_time = "33334";/* us */
+						embedded_metadata_height = "1";
+
+						/* WDR related settings */
+						num_control_point = "4";
+						control_point_x_0 = "0";
+						control_point_x_1 = "2048";
+						control_point_x_2 = "16384";
+						control_point_x_3 = "65536";
+						control_point_y_0 = "0";
+						control_point_y_1 = "2048";
+						control_point_y_2 = "2944";
+						control_point_y_3 = "3712";
+					};
+                    
+                    ports {
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+
+                        port@0 {
+                            reg = <0>;
+                            imx185_out5: endpoint {
+                                port-index = <5>;
+                                bus-width = <2>;
+                                remote-endpoint = <&csi_in5>;
+                            };
+                        };
+                    }; 
+                };
+                pca9570_f@24 {
+                    compatible = "nvidia,pca9570";
+                    reg = <0x24>;
+                    channel = "f";
+                    drive_ic= "DRV8838";
+                   };
+
+            };
+        };
+    };
+
+/**********************VI******************************************************************/
+
+     host1x {
+        vi@15700000 {
+            num-channels = <6>; //set number of channels
+            status = "okay";
+            ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+                port@0 {
+					reg = <0>;
+                    status = "okay";
+                    vi_in0: endpoint {
+                        status = "okay";
+                        port-index = <0>;
+                        bus-width = <2>;
+                        remote-endpoint = <&csi_out0>; 
+                    };
+                };
+
+                port@1 {
+					reg = <1>;
+                    status = "okay";
+                    vi_in1: endpoint {
+                        status = "okay";
+                        port-index = <1>;
+                        bus-width = <2>;
+                        remote-endpoint = <&csi_out1>; 
+                    };
+                };
+                port@2 {
+					reg = <2>;
+                    status = "okay";
+                    vi_in2: endpoint {
+                        status = "okay";
+                        port-index = <2>;
+                        bus-width = <2>;
+                        remote-endpoint = <&csi_out2>; 
+                    };
+                };
+                port@3 {
+					reg = <3>;
+                    status = "okay";
+                    vi_in3: endpoint {
+                        status = "okay";
+                        port-index = <3>;
+                        bus-width = <2>;
+                        remote-endpoint = <&csi_out3>; 
+                    };
+                };
+
+                port@4 {
+					reg = <4>;
+                    status = "okay";
+                    vi_in4: endpoint {
+                        status = "okay";
+                        port-index = <4>;
+                        bus-width = <2>;
+                        remote-endpoint = <&csi_out4>; 
+                    };
+                };
+                port@5 {
+					reg = <5>;
+                    status = "okay";
+                    vi_in5: endpoint {
+                        status = "okay";
+                        port-index = <5>;
+                        bus-width = <2>;
+                        remote-endpoint = <&csi_out5>; 
+                    };
+                };
+            };
+        };
+
+/**********************CSI******************************************************************/
+        nvcsi@150c0000 {
+            num-channels = <6>;
+
+            channel@0 {
+                status = "okay";
+                ports {
+					#address-cells = <1>;
+					#size-cells = <0>;
+                    port@0 {
+						reg = <0>;
+                        status = "okay";
+                        csi_in0: endpoint@0 {
+                            port-index = <0>;
+                            bus-width = <2>;
+                            remote-endpoint = <&imx185_out0>; //should be sensor port under i2c endpoint
+                            status = "okay";
+
+                        };
+                    };
+                    port@1 {
+						reg = <1>;
+                        status = "okay";
+                        csi_out0: endpoint@1 {
+                            status = "okay";
+                            remote-endpoint = <&vi_in0>; 
+                        };
+                    };
+                };
+            };
+
+            channel@1 {
+                status = "okay";
+                ports {
+					#address-cells = <1>;
+					#size-cells = <0>;
+                    port@0 {
+						reg = <0>;
+                        status = "okay";
+                        csi_in1: endpoint@2 {
+                            port-index = <1>;
+                            bus-width = <2>;
+                            remote-endpoint = <&imx185_out1>; //should be sensor port under i2c endpoint
+                            status = "okay";
+
+                        };
+                    };
+                    port@1 {
+						reg = <1>;
+                        status = "okay";
+                        csi_out1: endpoint@3 {
+                            status = "okay";
+                            remote-endpoint = <&vi_in1>; 
+                        };
+                    };
+                };
+            };
+            channel@2 {
+                status = "okay";
+                ports {
+					#address-cells = <1>;
+					#size-cells = <0>;
+                    port@0 {
+						reg = <0>;
+                        status = "okay";
+                        csi_in2: endpoint@4 {
+                            port-index = <2>;
+                            bus-width = <2>;
+                            remote-endpoint = <&imx185_out2>; //should be sensor port under i2c endpoint
+                            status = "okay";
+                        };
+                    };
+                    port@1 {
+						reg = <1>;
+                        status = "okay";
+                        csi_out2: endpoint@5 {
+                            status = "okay";
+                            remote-endpoint = <&vi_in2>; 
+                        };
+                    };
+                };
+            };
+        
+
+            channel@3 {
+                status = "okay";
+                ports {
+					#address-cells = <1>;
+					#size-cells = <0>;
+                     port@0 {
+						reg = <0>;
+                        status = "okay";
+                        csi_in3: endpoint@6 {
+                            port-index = <3>;
+                            bus-width = <2>;
+                            remote-endpoint = <&imx185_out3>; //should be sensor port under i2c endpoint
+                            status = "okay";
+
+                        };
+                    };
+                    port@1 {
+						reg = <1>;
+                        status = "okay";
+                        csi_out3: endpoint@7 {
+                            status = "okay";
+                            remote-endpoint = <&vi_in3>; 
+                        };
+                    };
+                };
+            };
+
+            channel@4 {
+                status = "okay";
+                ports {
+					#address-cells = <1>;
+					#size-cells = <0>;
+                    port@0 {
+						reg = <0>;
+                        status = "okay";
+                        csi_in4: endpoint@8 {
+                            port-index = <4>;
+                            bus-width = <2>;
+                            remote-endpoint = <&imx185_out4>; //should be sensor port under i2c endpoint
+                            status = "okay";
+
+                        };
+                    };
+                    port@1 {
+						reg = <1>;
+                        status = "okay";
+                        csi_out4: endpoint@9 {
+                            status = "okay";
+                            remote-endpoint = <&vi_in4>; 
+                        };
+                    };
+                };
+            };
+            channel@5 {
+                status = "okay";
+                ports {
+					#address-cells = <1>;
+					#size-cells = <0>;
+                    port@0 {
+						reg = <0>;
+                        status = "okay";
+                        csi_in5: endpoint@10 {
+                            port-index = <5>;
+                            bus-width = <2>;
+                            remote-endpoint = <&imx185_out5>; //should be sensor port under i2c endpoint
+                            status = "okay";
+                        };
+                    };
+                    port@1 {
+						reg = <1>;
+                        status = "okay";
+                        csi_out5: endpoint@11 {
+                            status = "okay";
+                            remote-endpoint = <&vi_in5>; 
+                        };
+                    };
+                };
+            };
+        };
+    };
+    lens_imx185@A6V26 {
+        min_focus_distance = "0.0";
+        hyper_focal = "0.0";
+        focal_length = "5.00";
+        f_number = "2.0";
+        aperture = "2.2";
+    };
+
+/**********************CAMERA PLATFORM*************************************************************/
+
+    tegra-camera-platform {
+        compatible = "nvidia, tegra-camera-platform";
+        /**
+        * Physical settings to calculate max ISO BW
+        *
+        * num_csi_lanes = <>;
+        * Total number of CSI lanes when all cameras are active
+        *
+        * max_lane_speed = <>;
+        * Max lane speed in Kbit/s
+        *
+        * min_bits_per_pixel = <>;
+        * Min bits per pixel
+        *
+        * vi_peak_byte_per_pixel = <>;
+        * Max byte per pixel for the VI ISO case
+        *
+        * vi_bw_margin_pct = <>;
+        * Vi bandwidth margin in percentage
+        *
+        * max_pixel_rate = <>;
+        * Max pixel rate in Kpixel/s for the ISP ISO case
+        * Set this to the highest pix_clk_hz out of all available modes.
+        *
+        * isp_peak_byte_per_pixel = <>;
+        * Max byte per pixel for the ISP ISO case
+        *
+        * isp_bw_margin_pct = <>;
+        * Isp bandwidth margin in percentage
+        */
+        num_csi_lanes = <12>;
+        max_lane_speed = <1500000>;
+        min_bits_per_pixel = <10>;
+        vi_peak_byte_per_pixel = <2>;
+        vi_bw_margin_pct = <25>;
+        max_pixel_rate = <750000>;
+        isp_peak_byte_per_pixel = <5>;
+        isp_bw_margin_pct = <25>;
+
+        /**
+        * The general guideline for naming badge_info contains 3 parts, and is as follows,
+        * The first part is the camera_board_id for the module; if the module is in a FFD
+        * platform, then use the platform name for this part.
+        * The second part contains the position of the module, ex. “rear” or “front”.
+        * The third part contains the last 6 characters of a part number which is found
+        * in the module's specsheet from the vender.
+        */
+        modules {
+
+            module0 {
+                badge = "imx185_topright_A6V26";
+                position = "topright";
+                orientation = "0";
+                status = "okay";
+                drivernode0 {
+                    status = "okay";
+                    pcl_id = "v4l2_sensor";
+                    devname = "imx185 30-001a";
+                    proc-device-tree = "/proc/device-tree/i2c@3180000/tca9546@70/i2c@0/imx185_a@1a";
+                };
+                drivernode1 {
+                    status = "okay";
+                    pcl_id = "v4l2_lens";
+                    proc-device-tree = "/proc/device-tree/lens_imx185@A6V26/";
+                };
+            };
+
+            module1 {
+                badge = "imx185_bottomright_A6V26";
+                position = "bottomright";
+                orientation = "0";
+                status = "okay";
+                drivernode0 {
+                status = "okay";
+                    pcl_id = "v4l2_sensor";
+                    devname = "imx185 31-001a";
+                    proc-device-tree = "/proc/device-tree/i2c@3180000/tca9546@70/i2c@1/imx185_b@1a";
+                };
+                drivernode1 {
+                status = "okay";
+                    pcl_id = "v4l2_lens";
+                    proc-device-tree = "/proc/device-tree/lens_imx185@A6V26/";
+                };
+            };
+
+            module2 {
+                badge = "imx185_centerleft_A6V26";
+                position = "centerleft";
+                orientation = "0";
+                status = "okay";
+                drivernode0 {
+                status = "okay";
+                    pcl_id = "v4l2_sensor";
+                    devname = "imx185 32-001a";
+                    proc-device-tree = "/proc/device-tree/i2c@3180000/tca9546@70/i2c@2/imx185_c@1a";
+                };
+                drivernode1 {
+                status = "okay";
+                    pcl_id = "v4l2_lens";
+                    proc-device-tree = "/proc/device-tree/lens_imx185@A6V26/";
+                };
+            };
+
+            module3 {
+                badge = "imx185_centerright_A6V26";
+                position = "centerright";
+                orientation = "0";
+                status = "okay";
+                drivernode0 {
+                    status = "okay";
+                    pcl_id = "v4l2_sensor";
+                    devname = "imx185 34-001a";
+                    proc-device-tree = "/proc/device-tree/i2c@c240000/tca9546@71/i2c@0/imx185_d@1a";
+                };
+                drivernode1 {
+                    status = "okay";
+                    pcl_id = "v4l2_lens";
+                    proc-device-tree = "/proc/device-tree/lens_imx185@A6V26/";
+                };
+            };
+
+            module4 {
+                badge = "imx185_topleft_A6V26";
+                position = "topleft";
+                orientation = "0";
+                status = "okay";
+                drivernode0 {
+                status = "okay";
+                    pcl_id = "v4l2_sensor";
+                    devname = "imx185 35-001a";
+                    proc-device-tree = "/proc/device-tree/i2c@c240000/tca9546@71/i2c@1/imx185_e@1a";
+                };
+                drivernode1 {
+                status = "okay";
+                    pcl_id = "v4l2_lens";
+                    proc-device-tree = "/proc/device-tree/lens_imx185@A6V26/";
+                };
+            };
+
+            module5 {
+                badge = "imx185_bottomleft_A6V26";
+                position = "bottomleft";
+                orientation = "0";
+                status = "okay";
+                drivernode0 {
+                status = "okay";
+                    pcl_id = "v4l2_sensor";
+                    devname = "imx185 36-001a";
+                    proc-device-tree = "/proc/device-tree/i2c@c240000/tca9546@71/i2c@2/imx185_f@1a";
+                };
+                drivernode1 {
+                status = "okay";
+                    pcl_id = "v4l2_lens";
+                    proc-device-tree = "/proc/device-tree/lens_imx185@A6V26/";
+                };
+            };
+        };
+    };
+};

--- a/nvidia/platform/t18x/quill/kernel-dts/tegra186-tx2-cti-ASG006-IMX274-3CAM.dts
+++ b/nvidia/platform/t18x/quill/kernel-dts/tegra186-tx2-cti-ASG006-IMX274-3CAM.dts
@@ -1,0 +1,562 @@
+#include <tegra186-tx2-cti-ASG006-base.dts>
+
+    
+
+#include <t18x-common-platforms/tegra186-tx2-cti-camera-base.dtsi>
+#include "dt-bindings/clock/tegra186-clock.h"
+
+
+/* camera control gpio definitions */
+
+#define CAM0_RST_L  TEGRA_MAIN_GPIO(R, 5)
+#define CAM0_PWDN   TEGRA_MAIN_GPIO(R, 0)
+#define CAM1_RST_L  TEGRA_MAIN_GPIO(R, 1)
+#define CAM1_PWDN   TEGRA_MAIN_GPIO(N, 2)
+
+
+/ {
+    
+    gpio@2200000 {
+        camera-control-output-low {
+            gpio-hog;
+            output-low;
+            gpios = <CAM0_RST_L 0 CAM0_PWDN 0
+                 CAM1_RST_L 0 CAM1_PWDN 0>;
+            label = "cam0-rst", "cam0-pwdn",
+                "cam1-rst", "cam1-pwdn";
+        };
+    };
+
+
+/**********************SENSORS******************************************************************/
+
+	i2c@3180000 {       //set this to correct i2c bus 
+        tca9546@70 {    
+            i2c@0{  //cam_i2c/Mux@70/I2C_A
+                #address-cells = <1>;
+                #size-cells = <0>;
+
+                imx274_a@1a {
+                    compatible = "nvidia,imx274";
+                    reg = <0x1a>;
+                    devnode = "video0";
+
+                    /* Physical dimensions of sensor */
+                    physical_w = "3.674";
+                    physical_h = "2.738";
+                    clocks = <&tegra_car TEGRA186_CLK_EXTPERIPH1>,
+                             <&tegra_car TEGRA186_CLK_PLLP_OUT0>;
+                    clock-names = "extperiph1", "pllp_grtba";
+                    mclk = "extperiph1";
+                    sensor_model = "imx274";
+                    delayed_gain = "true";
+                    reset-gpios = <&tegra_main_gpio CAM0_RST_L GPIO_ACTIVE_HIGH>;
+                    vana-supply = <&battery_reg>;
+                    vif-supply = <&battery_reg>;
+                    vdig-supply = <&battery_reg>;
+                    avdd-reg = "vana";
+                    iovdd-reg = "vif";
+                    dvdd-reg = "vdig";
+
+                    mode0 {
+                        mclk_khz = "24000";
+                        num_lanes = "4";
+                        tegra_sinterface = "serial_a";
+                        discontinuous_clk = "yes";
+                        dpcm_enable = "false";
+                        cil_settletime = "0";
+						phy_mode = "DPHY";
+
+                        active_w = "3840";
+						active_h = "2160";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+						csi_pixel_bit_depth = "10";
+						readout_orientation = "90";
+						line_length = "4208";
+						inherent_gain = "1";
+						mclk_multiplier = "24";
+						pix_clk_hz = "576000000";
+
+						gain_factor = "1000000";
+						min_gain_val = "1000000";
+						max_gain_val = "44400000";
+						step_gain_val = "1";
+						default_gain = "1000000";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000";
+						max_framerate = "60000000";
+						step_framerate = "1";
+						default_framerate= "60000000";
+						exposure_factor = "1000000";
+						min_exp_time = "44";
+						max_exp_time = "478696";
+						step_exp_time = "1";
+						default_exp_time = "16667";/* us */
+						//embedded_metadata_height = "1";
+                    };                    
+
+                    ports {
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+
+                        port@0 {
+                            reg = <0>;
+                            imx274_out0: endpoint {
+                                port-index = <0>;
+                                bus-width = <4>;
+                                remote-endpoint = <&csi_in0>;
+                            };
+                        };
+                    };
+                };
+                pca9570_a@24 {
+                    compatible = "nvidia,pca9570";
+                    reg = <0x24>;
+                    channel = "a";
+                    drive_ic= "DRV8838";
+                };
+
+
+
+            };
+            i2c@2 {
+                #address-cells = <1>;
+                #size-cells = <0>;
+                imx274_c@1a {
+                    compatible = "nvidia,imx274";
+                    reg = <0x1a>;
+                    devnode = "video1";
+
+                    /* Physical dimensions of sensor */
+                    physical_w = "3.674";
+                    physical_h = "2.738";
+
+                    /* Define any required hw resources needed by driver */
+                    /* ie. clocks, io pins, power sources */
+                    clocks = <&tegra_car TEGRA186_CLK_EXTPERIPH2>,
+                         <&tegra_car TEGRA186_CLK_PLLP_OUT0>;
+                    clock-names = "extperiph2", "pllp_grtba";
+                    mclk = "extperiph2";
+                    reset-gpios = <&gpio_i2c_0_74 1 GPIO_ACTIVE_HIGH>;
+                    vana-supply = <&battery_reg>;
+                    vif-supply = <&battery_reg>;
+                    vdig-supply = <&battery_reg>;
+                    avdd-reg = "vana";
+                    iovdd-reg = "vif";
+                    dvdd-reg = "vdig";
+
+                    mode0 {
+                        mclk_khz = "24000";
+                        num_lanes = "4";
+                        tegra_sinterface = "serial_c";
+                        discontinuous_clk = "yes";
+                        dpcm_enable = "false";
+                        cil_settletime = "0";
+						phy_mode = "DPHY";
+
+                        active_w = "3840";
+						active_h = "2160";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+						csi_pixel_bit_depth = "10";
+						readout_orientation = "90";
+						line_length = "4208";
+						inherent_gain = "1";
+						mclk_multiplier = "24";
+						pix_clk_hz = "576000000";
+
+						gain_factor = "1000000";
+						min_gain_val = "1000000";
+						max_gain_val = "44400000";
+						step_gain_val = "1";
+						default_gain = "1000000";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000";
+						max_framerate = "60000000";
+						step_framerate = "1";
+						default_framerate= "60000000";
+						exposure_factor = "1000000";
+						min_exp_time = "44";
+						max_exp_time = "478696";
+						step_exp_time = "1";
+						default_exp_time = "16667";/* us */
+						//embedded_metadata_height = "1";                    
+					};
+
+                    
+                    ports {
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+
+                        port@0 {
+                            reg = <0>;
+                            imx274_out2: endpoint {
+                                port-index = <2>;
+                                bus-width = <4>;
+                                remote-endpoint = <&csi_in1>;
+                            };
+                        };
+                    };
+                };
+
+                pca9570_b@24 {
+                    compatible = "nvidia,pca9570";
+                    reg = <0x24>;
+                    channel = "b";
+                    drive_ic= "DRV8838";
+                };
+
+
+            };
+        };
+	};
+   i2c@c240000 {
+        tca9546@71{
+            i2c@1 {
+                #address-cells = <1>;
+                #size-cells = <0>;
+                imx274_e@1a {
+                    compatible = "nvidia,imx274";
+                    reg = <0x1a>;
+                    devnode = "video2";
+                    /* Physical dimensions of sensor */
+
+                    physical_w = "3.674";
+                    physical_h = "2.738";
+                    /* Define any required hw resources needed by driver */
+                    /* ie. clocks, io pins, power sources */
+                    clocks = <&tegra_car TEGRA186_CLK_EXTPERIPH1>,
+                             <&tegra_car TEGRA186_CLK_PLLP_OUT0>;
+                    clock-names = "extperiph1", "pllp_grtba";
+                    mclk = "extperiph1";
+                    reset-gpios = <&gpio_i2c_0_74 5 GPIO_ACTIVE_HIGH>;
+                    vana-supply = <&battery_reg>;
+                    vif-supply = <&battery_reg>;
+                    vdig-supply = <&battery_reg>;
+
+
+
+                    /* Define any required hw resources needed by driver */
+                    /* ie. clocks, io pins, power sources */
+                    avdd-reg = "vana";
+                    iovdd-reg = "vif";
+                    dvdd-reg = "vdig";
+
+                    mode0 {
+                        mclk_khz = "24000";
+                        num_lanes = "4";
+                        tegra_sinterface = "serial_e";
+                        discontinuous_clk = "yes";
+                        dpcm_enable = "false";
+                        cil_settletime = "0";
+						phy_mode = "DPHY";
+
+                        active_w = "3840";
+						active_h = "2160";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+						csi_pixel_bit_depth = "10";
+						readout_orientation = "90";
+						line_length = "4208";
+						inherent_gain = "1";
+						mclk_multiplier = "24";
+						pix_clk_hz = "576000000";
+
+						gain_factor = "1000000";
+						min_gain_val = "1000000";
+						max_gain_val = "44400000";
+						step_gain_val = "1";
+						default_gain = "1000000";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000";
+						max_framerate = "60000000";
+						step_framerate = "1";
+						default_framerate= "60000000";
+						exposure_factor = "1000000";
+						min_exp_time = "44";
+						max_exp_time = "478696";
+						step_exp_time = "1";
+						default_exp_time = "16667";/* us */
+						//embedded_metadata_height = "1";
+					};
+                    
+                    ports {
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+
+                        port@0 {
+                            reg = <0>;
+                            imx274_out4: endpoint {
+                                port-index = <4>;
+                                bus-width = <4>;
+                                remote-endpoint = <&csi_in2>;
+                            };
+                        };
+                    }; 
+                };
+                
+                pca9570_c@24 {
+                    compatible = "nvidia,pca9570";
+                    reg = <0x24>;
+                    channel = "c";
+                    drive_ic= "DRV8838";
+                };
+
+            };
+        };
+    };
+
+/**********************VI******************************************************************/
+
+     host1x {
+        vi@15700000 {
+            num-channels = <3>; //set number of channels
+            status = "okay";
+            ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+                port@0 {
+					reg = <0>;
+                    status = "okay";
+                    vi_in0: endpoint {
+                        status = "okay";
+                        port-index = <0>;
+                        bus-width = <4>;
+                        remote-endpoint = <&csi_out0>; 
+                    };
+                };
+
+                port@1 {
+					reg = <1>;
+                    status = "okay";
+                    vi_in1: endpoint {
+                        status = "okay";
+                        port-index = <2>;
+                        bus-width = <4>;
+                        remote-endpoint = <&csi_out1>; 
+                    };
+                };
+                port@2 {
+					reg = <2>;
+                    status = "okay";
+                    vi_in2: endpoint {
+                        status = "okay";
+                        port-index = <4>;
+                        bus-width = <4>;
+                        remote-endpoint = <&csi_out2>; 
+                    };
+                };
+            };
+        };
+
+/**********************CSI******************************************************************/
+        nvcsi@150c0000 {
+            num-channels = <3>;
+			#address-cells = <1>;
+			#size-cells = <0>;
+            channel@0 {
+				reg = <0>;
+                status = "okay";
+                ports {
+					#address-cells = <1>;
+					#size-cells = <0>;
+                     port@0 {
+						reg = <0>;
+                        status = "okay";
+                        csi_in0: endpoint@0 {
+                            port-index = <0>;
+                            bus-width = <4>;
+                            remote-endpoint = <&imx274_out0>; //should be sensor port under i2c endpoint
+                            status = "okay";
+
+                        };
+                    };
+                    port@1 {
+						reg = <1>;
+                        status = "okay";
+                        csi_out0: endpoint@1 {
+                            status = "okay";
+                            remote-endpoint = <&vi_in0>; 
+                        };
+                    };
+                };
+            };
+
+            channel@1 {
+				reg = <1>;
+                status = "okay";
+                ports {
+					#address-cells = <1>;
+					#size-cells = <0>;
+                    port@0 {
+						reg = <0>;
+                        status = "okay";
+                        csi_in1: endpoint@2 {
+                            port-index = <2>;
+                            bus-width = <4>;
+                            remote-endpoint = <&imx274_out2>; //should be sensor port under i2c endpoint
+                            status = "okay";
+
+                        };
+                    };
+                    port@1 {
+						reg = <1>;
+                        status = "okay";
+                        csi_out1: endpoint@3 {
+                            status = "okay";
+                            remote-endpoint = <&vi_in1>; 
+                        };
+                    };
+                };
+            };
+            channel@2 {
+				reg = <2>;
+                status = "okay";				
+                ports {
+					#address-cells = <1>;
+					#size-cells = <0>;
+                    port@0 {
+						reg = <0>;
+                        status = "okay";
+                        csi_in2: endpoint@4 {
+                            port-index = <4>;
+                            bus-width = <4>;
+                            remote-endpoint = <&imx274_out4>; //should be sensor port under i2c endpoint
+                            status = "okay";
+                        };
+                    };
+                    port@1 {
+						reg = <1>;
+                        status = "okay";
+                        csi_out2: endpoint@5 {
+                            status = "okay";
+                            remote-endpoint = <&vi_in2>; 
+                        };
+                    };
+                };
+            };
+        };
+    };
+    lens_imx274@A6V26 {
+        min_focus_distance = "0.0";
+        hyper_focal = "0.0";
+        focal_length = "5.00";
+        f_number = "2.0";
+        aperture = "2.2";
+    };
+
+/**********************CAMERA PLATFORM*************************************************************/
+
+    tegra-camera-platform {
+        compatible = "nvidia, tegra-camera-platform";
+        /**
+        * Physical settings to calculate max ISO BW
+        *
+        * num_csi_lanes = <>;
+        * Total number of CSI lanes when all cameras are active
+        *
+        * max_lane_speed = <>;
+        * Max lane speed in Kbit/s
+        *
+        * min_bits_per_pixel = <>;
+        * Min bits per pixel
+        *
+        * vi_peak_byte_per_pixel = <>;
+        * Max byte per pixel for the VI ISO case
+        *
+        * vi_bw_margin_pct = <>;
+        * Vi bandwidth margin in percentage
+        *
+        * max_pixel_rate = <>;
+        * Max pixel rate in Kpixel/s for the ISP ISO case
+        * Set this to the highest pix_clk_hz out of all available modes.
+        *
+        * isp_peak_byte_per_pixel = <>;
+        * Max byte per pixel for the ISP ISO case
+        *
+        * isp_bw_margin_pct = <>;
+        * Isp bandwidth margin in percentage
+        */
+        num_csi_lanes = <12>;
+        max_lane_speed = <1500000>;
+        min_bits_per_pixel = <10>;
+        vi_peak_byte_per_pixel = <2>;
+        vi_bw_margin_pct = <25>;
+        max_pixel_rate = <750000>;
+        isp_peak_byte_per_pixel = <5>;
+        isp_bw_margin_pct = <25>;
+
+        /**
+        * The general guideline for naming badge_info contains 3 parts, and is as follows,
+        * The first part is the camera_board_id for the module; if the module is in a FFD
+        * platform, then use the platform name for this part.
+        * The second part contains the position of the module, ex. “rear” or “front”.
+        * The third part contains the last 6 characters of a part number which is found
+        * in the module's specsheet from the vender.
+        */
+        modules {
+
+            module0 {
+                badge = "imx274_bottom_A6V26";
+                position = "bottom";
+                orientation = "0";
+                status = "okay";
+                drivernode0 {
+                    status = "okay";
+                    pcl_id = "v4l2_sensor";
+                    devname = "imx274 30-001a";
+                    proc-device-tree = "/proc/device-tree/i2c@3180000/tca9546@70/i2c@0/imx274_a@1a";
+                };
+                drivernode1 {
+                    status = "okay";
+                    pcl_id = "v4l2_lens";
+                    proc-device-tree = "/proc/device-tree/lens_imx274@A6V26/";
+                };
+            };
+
+            module1 {
+                badge = "imx274_top_A6V26";
+                position = "top";
+                orientation = "0";
+                status = "okay";
+                drivernode0 {
+                status = "okay";
+                    pcl_id = "v4l2_sensor";
+                    devname = "imx274 32-001a";
+                    proc-device-tree = "/proc/device-tree/i2c@3180000/tca9546@70/i2c@2/imx274_c@1a";
+                };
+                drivernode1 {
+                status = "okay";
+                    pcl_id = "v4l2_lens";
+                    proc-device-tree = "/proc/device-tree/lens_imx274@A6V26/";
+                };
+            };
+
+            module2 {
+                badge = "imx274_center_A6V26";
+                position = "center";
+                orientation = "0";
+                status = "okay";
+                drivernode0 {
+                status = "okay";
+                    pcl_id = "v4l2_sensor";
+                    devname = "imx274 35-001a";
+                    proc-device-tree = "/proc/device-tree/i2c@c240000/tca9546@71/i2c@1/imx274_e@1a";
+                };
+                drivernode1 {
+                status = "okay";
+                    pcl_id = "v4l2_lens";
+                    proc-device-tree = "/proc/device-tree/lens_imx274@A6V26/";
+                };
+            };
+        };
+    };
+};
+

--- a/nvidia/platform/t18x/quill/kernel-dts/tegra186-tx2-cti-ASG006-IMX274-6CAM.dts
+++ b/nvidia/platform/t18x/quill/kernel-dts/tegra186-tx2-cti-ASG006-IMX274-6CAM.dts
@@ -1,0 +1,994 @@
+#include <tegra186-tx2-cti-ASG006-base.dts>
+#include <t18x-common-platforms/tegra186-tx2-cti-camera-base.dtsi>
+#include "dt-bindings/clock/tegra186-clock.h"
+
+
+/* camera control gpio definitions */
+
+#define CAM0_RST_L  TEGRA_MAIN_GPIO(R, 5)
+#define CAM0_PWDN   TEGRA_MAIN_GPIO(R, 0)
+#define CAM1_RST_L  TEGRA_MAIN_GPIO(R, 1)
+#define CAM1_PWDN   TEGRA_MAIN_GPIO(N, 2)
+
+
+/ {
+    
+    gpio@2200000 {
+        camera-control-output-low {
+            gpio-hog;
+            output-low;
+            gpios = <CAM0_RST_L 0 CAM0_PWDN 0
+                 CAM1_RST_L 0 CAM1_PWDN 0>;
+            label = "cam0-rst", "cam0-pwdn",
+                "cam1-rst", "cam1-pwdn";
+        };
+    };
+
+
+/**********************SENSORS******************************************************************/
+
+	i2c@3180000 {       //set this to correct i2c bus 
+        tca9546@70{    
+            i2c@0{  //cam_i2c/Mux@70/I2C_A
+                #address-cells = <1>;
+                #size-cells = <0>;
+
+                imx274_a@1a {
+                    compatible = "nvidia,imx274";
+                    reg = <0x1a>;
+                    devnode = "video0";
+
+                    /* Physical dimensions of sensor */
+                    physical_w = "3.674";
+                    physical_h = "2.738";
+                    clocks = <&tegra_car TEGRA186_CLK_EXTPERIPH1>,
+                             <&tegra_car TEGRA186_CLK_PLLP_OUT0>;
+                    clock-names = "extperiph1", "pllp_grtba";
+                    mclk = "extperiph1";
+                    sensor_model = "imx274";
+                    delayed_gain = "true";
+                    reset-gpios = <&tegra_main_gpio CAM0_RST_L GPIO_ACTIVE_HIGH>;
+                    vana-supply = <&battery_reg>;
+                    vif-supply = <&battery_reg>;
+                    vdig-supply = <&battery_reg>;
+                    avdd-reg = "vana";
+                    iovdd-reg = "vif";
+                    dvdd-reg = "vdig";
+
+                    mode0 {
+                        mclk_khz = "24000";
+                        num_lanes = "2";
+                        tegra_sinterface = "serial_a";
+                        discontinuous_clk = "yes";
+                        dpcm_enable = "false";
+                        cil_settletime = "0";
+						phy_mode = "DPHY";
+
+                        active_w = "3840";
+						active_h = "2160";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+						csi_pixel_bit_depth = "10";
+						readout_orientation = "90";
+						line_length = "4208";
+						inherent_gain = "1";
+						mclk_multiplier = "24";
+						pix_clk_hz = "576000000";
+
+						gain_factor = "1000000";
+						min_gain_val = "1000000";
+						max_gain_val = "44400000";
+						step_gain_val = "1";
+						default_gain = "1000000";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000";
+						max_framerate = "60000000";
+						step_framerate = "1";
+						default_framerate= "60000000";
+						exposure_factor = "1000000";
+						min_exp_time = "44";
+						max_exp_time = "478696";
+						step_exp_time = "1";
+						default_exp_time = "16667";/* us */
+						//embedded_metadata_height = "1";
+                    };
+                    
+
+                    ports {
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+
+                        port@0 {
+                            reg = <0>;
+                            imx274_out0: endpoint {
+                                port-index = <0>;
+                                bus-width = <2>;
+                                remote-endpoint = <&csi_in0>;
+                            };
+                        };
+                    };
+                };
+
+                pca9570_a@24 {
+                    compatible = "nvidia,pca9570";
+                    reg = <0x24>;
+                    channel = "a";
+                    drive_ic= "DRV8838";
+                   };
+
+            };
+
+
+            i2c@1{  //cam_i2c/Mux@70/I2C_B
+                #address-cells = <1>;
+                #size-cells = <0>;
+
+                imx274_b@1a {
+                    compatible = "nvidia,imx274";
+                    reg = <0x1a>;
+                    devnode = "video1";
+
+                    /* Physical dimensions of sensor */
+                    physical_w = "3.674";
+                    physical_h = "2.738";
+                    clocks = <&tegra_car TEGRA186_CLK_EXTPERIPH1>,
+                             <&tegra_car TEGRA186_CLK_PLLP_OUT0>;
+                    clock-names = "extperiph1", "pllp_grtba";
+                    mclk = "extperiph1";
+                    sensor_model = "imx274";
+                    delayed_gain = "true";
+                    reset-gpios = <&tegra_main_gpio CAM1_RST_L GPIO_ACTIVE_HIGH>;
+                    vana-supply = <&battery_reg>;
+                    vif-supply = <&battery_reg>;
+                    vdig-supply = <&battery_reg>;
+                    avdd-reg = "vana";
+                    iovdd-reg = "vif";
+                    dvdd-reg = "vdig";
+
+                    mode0 {
+                        mclk_khz = "24000";
+                        num_lanes = "2";
+                        tegra_sinterface = "serial_b";
+                        discontinuous_clk = "yes";
+                        dpcm_enable = "false";
+                        cil_settletime = "0";
+						phy_mode = "DPHY";
+
+                        active_w = "3840";
+						active_h = "2160";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+						csi_pixel_bit_depth = "10";
+						readout_orientation = "90";
+						line_length = "4208";
+						inherent_gain = "1";
+						mclk_multiplier = "24";
+						pix_clk_hz = "576000000";
+
+						gain_factor = "1000000";
+						min_gain_val = "1000000";
+						max_gain_val = "44400000";
+						step_gain_val = "1";
+						default_gain = "1000000";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000";
+						max_framerate = "60000000";
+						step_framerate = "1";
+						default_framerate= "60000000";
+						exposure_factor = "1000000";
+						min_exp_time = "44";
+						max_exp_time = "478696";
+						step_exp_time = "1";
+						default_exp_time = "16667";/* us */
+						//embedded_metadata_height = "1";
+                    };
+                    
+
+
+                    ports {
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+
+                        port@0 {
+                            reg = <0>;
+                            imx274_out1: endpoint {
+                                port-index = <1>;
+                                bus-width = <2>;
+                                remote-endpoint = <&csi_in1>;
+                            };
+                        };
+                    };
+                };
+
+                pca9570_b@24 {
+                    compatible = "nvidia,pca9570";
+                    reg = <0x24>;
+                    channel = "b";
+                    drive_ic= "DRV8838";
+                   };
+
+            };
+
+
+            i2c@2 { //cam_i2c/Mux@70/I2C_C
+                #address-cells = <1>;
+                #size-cells = <0>;
+                imx274_c@1a {
+                    compatible = "nvidia,imx274";
+                    reg = <0x1a>;
+                    devnode = "video2";
+
+                    /* Physical dimensions of sensor */
+                    physical_w = "3.674";
+                    physical_h = "2.738";
+
+                    /* Define any required hw resources needed by driver */
+                    /* ie. clocks, io pins, power sources */
+                    clocks = <&tegra_car TEGRA186_CLK_EXTPERIPH2>,
+                         <&tegra_car TEGRA186_CLK_PLLP_OUT0>;
+                    clock-names = "extperiph2", "pllp_grtba";
+                    mclk = "extperiph2";
+                    reset-gpios = <&gpio_i2c_0_74 1 GPIO_ACTIVE_HIGH>;
+                    vana-supply = <&battery_reg>;
+                    vif-supply = <&battery_reg>;
+                    vdig-supply = <&battery_reg>;
+                    avdd-reg = "vana";
+                    iovdd-reg = "vif";
+                    dvdd-reg = "vdig";
+
+                    mode0 {
+                        mclk_khz = "24000";
+                        num_lanes = "2";
+                        tegra_sinterface = "serial_c";
+                        discontinuous_clk = "yes";
+                        dpcm_enable = "false";
+                        cil_settletime = "0";
+						phy_mode = "DPHY";
+
+                        active_w = "3840";
+						active_h = "2160";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+						csi_pixel_bit_depth = "10";
+						readout_orientation = "90";
+						line_length = "4208";
+						inherent_gain = "1";
+						mclk_multiplier = "24";
+						pix_clk_hz = "576000000";
+
+						gain_factor = "1000000";
+						min_gain_val = "1000000";
+						max_gain_val = "44400000";
+						step_gain_val = "1";
+						default_gain = "1000000";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000";
+						max_framerate = "60000000";
+						step_framerate = "1";
+						default_framerate= "60000000";
+						exposure_factor = "1000000";
+						min_exp_time = "44";
+						max_exp_time = "478696";
+						step_exp_time = "1";
+						default_exp_time = "16667";/* us */
+						//embedded_metadata_height = "1";
+                    };                    
+
+                    ports {
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+
+                        port@0 {
+                            reg = <0>;
+                            imx274_out2: endpoint {
+                                port-index = <2>;
+                                bus-width = <2>;
+                                remote-endpoint = <&csi_in2>;
+                            };
+                        };
+                    };
+                };
+
+                pca9570_c@24 {
+                    compatible = "nvidia,pca9570";
+                    reg = <0x24>;
+                    channel = "c";
+                    drive_ic= "DRV8838";
+                   };
+
+            };
+        };
+	};
+
+    i2c@c240000 {
+        tca9546@71{
+            i2c@0 { //gen_i2c_0/Mux@71/I2C_D
+                #address-cells = <1>;
+                #size-cells = <0>;
+                imx274_d@1a {
+                    compatible = "nvidia,imx274";
+                    reg = <0x1a>;
+                    devnode = "video3";
+                    /* Physical dimensions of sensor */
+
+                    physical_w = "3.674";
+                    physical_h = "2.738";
+                    /* Define any required hw resources needed by driver */
+                    /* ie. clocks, io pins, power sources */
+                    clocks = <&tegra_car TEGRA186_CLK_EXTPERIPH2>,
+                             <&tegra_car TEGRA186_CLK_PLLP_OUT0>;
+                    clock-names = "extperiph2", "pllp_grtba";
+                    mclk = "extperiph2";
+                    reset-gpios = <&gpio_i2c_0_74 3 GPIO_ACTIVE_HIGH>;
+                    vana-supply = <&battery_reg>;
+                    vif-supply = <&battery_reg>;
+                    vdig-supply = <&battery_reg>;
+
+                    /* Define any required hw resources needed by driver */
+                    /* ie. clocks, io pins, power sources */
+                    avdd-reg = "vana";
+                    iovdd-reg = "vif";
+                    dvdd-reg = "vdig";
+
+                    mode0 {
+                        mclk_khz = "24000";
+                        num_lanes = "2";
+                        tegra_sinterface = "serial_d";
+                        discontinuous_clk = "yes";
+                        dpcm_enable = "false";
+                        cil_settletime = "0";
+						phy_mode = "DPHY";
+
+                        active_w = "3840";
+						active_h = "2160";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+						csi_pixel_bit_depth = "10";
+						readout_orientation = "90";
+						line_length = "4208";
+						inherent_gain = "1";
+						mclk_multiplier = "24";
+						pix_clk_hz = "576000000";
+
+						gain_factor = "1000000";
+						min_gain_val = "1000000";
+						max_gain_val = "44400000";
+						step_gain_val = "1";
+						default_gain = "1000000";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000";
+						max_framerate = "60000000";
+						step_framerate = "1";
+						default_framerate= "60000000";
+						exposure_factor = "1000000";
+						min_exp_time = "44";
+						max_exp_time = "478696";
+						step_exp_time = "1";
+						default_exp_time = "16667";/* us */
+						//embedded_metadata_height = "1";
+                    };
+
+                    
+                    ports {
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+
+                        port@0 {
+                            reg = <0>;
+                            imx274_out3: endpoint {
+                                port-index = <3>;
+                                bus-width = <2>;
+                                remote-endpoint = <&csi_in3>;
+                            };
+                        };
+                    }; 
+                };
+                pca9570_d@24 {
+                    compatible = "nvidia,pca9570";
+                    reg = <0x24>;
+                    channel = "d";
+                    drive_ic= "DRV8838";
+                   };
+            };
+
+            i2c@1 { //gen_i2c_0/Mux@71/I2C_E
+                #address-cells = <1>;
+                #size-cells = <0>;
+                imx274_e@1a {
+                    compatible = "nvidia,imx274";
+                    reg = <0x1a>;
+                    devnode = "video4";
+                    /* Physical dimensions of sensor */
+
+                    physical_w = "3.674";
+                    physical_h = "2.738";
+                    /* Define any required hw resources needed by driver */
+                    /* ie. clocks, io pins, power sources */
+                    clocks = <&tegra_car TEGRA186_CLK_EXTPERIPH1>,
+                             <&tegra_car TEGRA186_CLK_PLLP_OUT0>;
+                    clock-names = "extperiph1", "pllp_grtba";
+                    mclk = "extperiph1";
+                    reset-gpios = <&gpio_i2c_0_74 5 GPIO_ACTIVE_HIGH>;
+                    vana-supply = <&battery_reg>;
+                    vif-supply = <&battery_reg>;
+                    vdig-supply = <&battery_reg>;
+
+
+
+                    /* Define any required hw resources needed by driver */
+                    /* ie. clocks, io pins, power sources */
+                    avdd-reg = "vana";
+                    iovdd-reg = "vif";
+                    dvdd-reg = "vdig";
+
+                    mode0 {
+                        mclk_khz = "24000";
+                        num_lanes = "2";
+                        tegra_sinterface = "serial_e";
+                        discontinuous_clk = "yes";
+                        dpcm_enable = "false";
+                        cil_settletime = "0";
+						phy_mode = "DPHY";
+
+                        active_w = "3840";
+						active_h = "2160";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+						csi_pixel_bit_depth = "10";
+						readout_orientation = "90";
+						line_length = "4208";
+						inherent_gain = "1";
+						mclk_multiplier = "24";
+						pix_clk_hz = "576000000";
+
+						gain_factor = "1000000";
+						min_gain_val = "1000000";
+						max_gain_val = "44400000";
+						step_gain_val = "1";
+						default_gain = "1000000";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000";
+						max_framerate = "60000000";
+						step_framerate = "1";
+						default_framerate= "60000000";
+						exposure_factor = "1000000";
+						min_exp_time = "44";
+						max_exp_time = "478696";
+						step_exp_time = "1";
+						default_exp_time = "16667";/* us */
+						//embedded_metadata_height = "1";
+                    };
+                    
+                    ports {
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+
+                        port@0 {
+                            reg = <0>;
+                            imx274_out4: endpoint {
+                                port-index = <4>;
+                                bus-width = <2>;
+                                remote-endpoint = <&csi_in4>;
+                            };
+                        };
+                    }; 
+                };
+
+                pca9570_e@24 {
+                    compatible = "nvidia,pca9570";
+                    reg = <0x24>;
+                    channel = "e";
+                    drive_ic= "DRV8838";
+                   };
+            };
+
+            i2c@2 { //gen_i2c_0/Mux@71/I2C_F
+                #address-cells = <1>;
+                #size-cells = <0>;
+                imx274_f@1a {
+                    compatible = "nvidia,imx274";
+                    reg = <0x1a>;
+                    devnode = "video5";
+                    /* Physical dimensions of sensor */
+
+                    physical_w = "3.674";
+                    physical_h = "2.738";
+                    /* Define any required hw resources needed by driver */
+                    /* ie. clocks, io pins, power sources */
+                    clocks = <&tegra_car TEGRA186_CLK_EXTPERIPH2>,
+                             <&tegra_car TEGRA186_CLK_PLLP_OUT0>;
+                    clock-names = "extperiph2", "pllp_grtba";
+                    mclk = "extperiph2";
+                    reset-gpios = <&gpio_i2c_0_74 7 GPIO_ACTIVE_HIGH>;
+                    vana-supply = <&battery_reg>;
+                    vif-supply = <&battery_reg>;
+                    vdig-supply = <&battery_reg>;
+
+                    /* Define any required hw resources needed by driver */
+                    /* ie. clocks, io pins, power sources */
+                    avdd-reg = "vana";
+                    iovdd-reg = "vif";
+                    dvdd-reg = "vdig";
+
+                    mode0 {
+                        mclk_khz = "24000";
+                        num_lanes = "2";
+                        tegra_sinterface = "serial_f";
+                        discontinuous_clk = "yes";
+                        dpcm_enable = "false";
+                        cil_settletime = "0";
+						phy_mode = "DPHY";						
+
+                        active_w = "3840";
+						active_h = "2160";
+						mode_type = "bayer";
+						pixel_phase = "rggb";
+						csi_pixel_bit_depth = "10";
+						readout_orientation = "90";
+						line_length = "4208";
+						inherent_gain = "1";
+						mclk_multiplier = "24";
+						pix_clk_hz = "576000000";
+
+						gain_factor = "1000000";
+						min_gain_val = "1000000";
+						max_gain_val = "44400000";
+						step_gain_val = "1";
+						default_gain = "1000000";
+						min_hdr_ratio = "1";
+						max_hdr_ratio = "1";
+						framerate_factor = "1000000";
+						min_framerate = "1500000";
+						max_framerate = "60000000";
+						step_framerate = "1";
+						default_framerate= "60000000";
+						exposure_factor = "1000000";
+						min_exp_time = "44";
+						max_exp_time = "478696";
+						step_exp_time = "1";
+						default_exp_time = "16667";/* us */
+						//embedded_metadata_height = "1";
+                    };
+                    
+                    ports {
+                        #address-cells = <1>;
+                        #size-cells = <0>;
+
+                        port@0 {
+                            reg = <0>;
+                            imx274_out5: endpoint {
+                                port-index = <5>;
+                                bus-width = <2>;
+                                remote-endpoint = <&csi_in5>;
+                            };
+                        };
+                    }; 
+                };
+                pca9570_f@24 {
+                    compatible = "nvidia,pca9570";
+                    reg = <0x24>;
+                    channel = "f";
+                    drive_ic= "DRV8838";
+                   };
+
+            };
+        };
+    };
+
+/**********************VI******************************************************************/
+
+     host1x {
+        vi@15700000 {
+            num-channels = <6>; //set number of channels
+            status = "okay";
+            ports {
+				#address-cells = <1>;
+				#size-cells = <0>;
+                port@0 {
+					reg = <0>;
+                    status = "okay";
+                    vi_in0: endpoint {
+                        status = "okay";
+                        port-index = <0>;
+                        bus-width = <2>;
+                        remote-endpoint = <&csi_out0>; 
+                    };
+                };
+
+                port@1 {
+					reg = <1>;
+                    status = "okay";
+                    vi_in1: endpoint {
+                        status = "okay";
+                        port-index = <1>;
+                        bus-width = <2>;
+                        remote-endpoint = <&csi_out1>; 
+                    };
+                };
+                port@2 {
+					reg = <2>;
+                    status = "okay";
+                    vi_in2: endpoint {
+                        status = "okay";
+                        port-index = <2>;
+                        bus-width = <2>;
+                        remote-endpoint = <&csi_out2>; 
+                    };
+                };
+                port@3 {
+					reg = <3>;
+                    status = "okay";
+                    vi_in3: endpoint {
+                        status = "okay";
+                        port-index = <3>;
+                        bus-width = <2>;
+                        remote-endpoint = <&csi_out3>; 
+                    };
+                };
+
+                port@4 {
+					reg = <4>;
+                    status = "okay";
+                    vi_in4: endpoint {
+                        status = "okay";
+                        port-index = <4>;
+                        bus-width = <2>;
+                        remote-endpoint = <&csi_out4>; 
+                    };
+                };
+                port@5 {
+					reg = <5>;
+                    status = "okay";
+                    vi_in5: endpoint {
+                        status = "okay";
+                        port-index = <5>;
+                        bus-width = <2>;
+                        remote-endpoint = <&csi_out5>; 
+                    };
+                };
+            };
+        };
+
+/**********************CSI******************************************************************/
+        nvcsi@150c0000 {
+            num-channels = <6>;
+
+            channel@0 {
+                status = "okay";
+                ports {
+					#address-cells = <1>;
+					#size-cells = <0>;
+                    port@0 {
+						reg = <0>;
+                        status = "okay";
+                        csi_in0: endpoint@0 {
+                            port-index = <0>;
+                            bus-width = <2>;
+                            remote-endpoint = <&imx274_out0>; //should be sensor port under i2c endpoint
+                            status = "okay";
+
+                        };
+                    };
+                    port@1 {
+						reg = <1>;
+                        status = "okay";
+                        csi_out0: endpoint@1 {
+                            status = "okay";
+                            remote-endpoint = <&vi_in0>; 
+                        };
+                    };
+                };
+            };
+
+            channel@1 {
+                status = "okay";
+                ports {
+					#address-cells = <1>;
+					#size-cells = <0>;
+                    port@0 {
+						reg = <0>;
+                        status = "okay";
+                        csi_in1: endpoint@2 {
+                            port-index = <1>;
+                            bus-width = <2>;
+                            remote-endpoint = <&imx274_out1>; //should be sensor port under i2c endpoint
+                            status = "okay";
+
+                        };
+                    };
+                    port@1 {
+						reg = <1>;
+                        status = "okay";
+                        csi_out1: endpoint@3 {
+                            status = "okay";
+                            remote-endpoint = <&vi_in1>; 
+                        };
+                    };
+                };
+            };
+            channel@2 {
+                status = "okay";
+                ports {
+					#address-cells = <1>;
+					#size-cells = <0>;
+                    port@0 {
+						reg = <0>;
+                        status = "okay";
+                        csi_in2: endpoint@4 {
+                            port-index = <2>;
+                            bus-width = <2>;
+                            remote-endpoint = <&imx274_out2>; //should be sensor port under i2c endpoint
+                            status = "okay";
+                        };
+                    };
+                    port@1 {
+						reg = <1>;
+                        status = "okay";
+                        csi_out2: endpoint@5 {
+                            status = "okay";
+                            remote-endpoint = <&vi_in2>; 
+                        };
+                    };
+                };
+            };
+        
+
+            channel@3 {
+                status = "okay";
+                ports {
+					#address-cells = <1>;
+					#size-cells = <0>;
+                     port@0 {
+						reg = <0>;
+                        status = "okay";
+                        csi_in3: endpoint@6 {
+                            port-index = <3>;
+                            bus-width = <2>;
+                            remote-endpoint = <&imx274_out3>; //should be sensor port under i2c endpoint
+                            status = "okay";
+
+                        };
+                    };
+                    port@1 {
+						reg = <1>;
+                        status = "okay";
+                        csi_out3: endpoint@7 {
+                            status = "okay";
+                            remote-endpoint = <&vi_in3>; 
+                        };
+                    };
+                };
+            };
+
+            channel@4 {
+                status = "okay";
+                ports {
+					#address-cells = <1>;
+					#size-cells = <0>;
+                    port@0 {
+						reg = <0>;
+                        status = "okay";
+                        csi_in4: endpoint@8 {
+                            port-index = <4>;
+                            bus-width = <2>;
+                            remote-endpoint = <&imx274_out4>; //should be sensor port under i2c endpoint
+                            status = "okay";
+
+                        };
+                    };
+                    port@1 {
+						reg = <1>;
+                        status = "okay";
+                        csi_out4: endpoint@9 {
+                            status = "okay";
+                            remote-endpoint = <&vi_in4>; 
+                        };
+                    };
+                };
+            };
+            channel@5 {
+                status = "okay";
+                ports {
+					#address-cells = <1>;
+					#size-cells = <0>;
+                    port@0 {
+						reg = <0>;
+                        status = "okay";
+                        csi_in5: endpoint@10 {
+                            port-index = <5>;
+                            bus-width = <2>;
+                            remote-endpoint = <&imx274_out5>; //should be sensor port under i2c endpoint
+                            status = "okay";
+                        };
+                    };
+                    port@1 {
+						reg = <1>;
+                        status = "okay";
+                        csi_out5: endpoint@11 {
+                            status = "okay";
+                            remote-endpoint = <&vi_in5>; 
+                        };
+                    };
+                };
+            };
+        };
+    };
+    lens_imx274@A6V26 {
+        min_focus_distance = "0.0";
+        hyper_focal = "0.0";
+        focal_length = "5.00";
+        f_number = "2.0";
+        aperture = "2.2";
+    };
+
+/**********************CAMERA PLATFORM*************************************************************/
+
+    tegra-camera-platform {
+        compatible = "nvidia, tegra-camera-platform";
+        /**
+        * Physical settings to calculate max ISO BW
+        *
+        * num_csi_lanes = <>;
+        * Total number of CSI lanes when all cameras are active
+        *
+        * max_lane_speed = <>;
+        * Max lane speed in Kbit/s
+        *
+        * min_bits_per_pixel = <>;
+        * Min bits per pixel
+        *
+        * vi_peak_byte_per_pixel = <>;
+        * Max byte per pixel for the VI ISO case
+        *
+        * vi_bw_margin_pct = <>;
+        * Vi bandwidth margin in percentage
+        *
+        * max_pixel_rate = <>;
+        * Max pixel rate in Kpixel/s for the ISP ISO case
+        * Set this to the highest pix_clk_hz out of all available modes.
+        *
+        * isp_peak_byte_per_pixel = <>;
+        * Max byte per pixel for the ISP ISO case
+        *
+        * isp_bw_margin_pct = <>;
+        * Isp bandwidth margin in percentage
+        */
+        num_csi_lanes = <12>;
+        max_lane_speed = <1500000>;
+        min_bits_per_pixel = <10>;
+        vi_peak_byte_per_pixel = <2>;
+        vi_bw_margin_pct = <25>;
+        max_pixel_rate = <750000>;
+        isp_peak_byte_per_pixel = <5>;
+        isp_bw_margin_pct = <25>;
+
+        /**
+        * The general guideline for naming badge_info contains 3 parts, and is as follows,
+        * The first part is the camera_board_id for the module; if the module is in a FFD
+        * platform, then use the platform name for this part.
+        * The second part contains the position of the module, ex. “rear” or “front”.
+        * The third part contains the last 6 characters of a part number which is found
+        * in the module's specsheet from the vender.
+        */
+        modules {
+
+            module0 {
+                badge = "imx274_topright_A6V26";
+                position = "topright";
+                orientation = "0";
+                status = "okay";
+                drivernode0 {
+                    status = "okay";
+                    pcl_id = "v4l2_sensor";
+                    devname = "imx274 30-001a";
+                    proc-device-tree = "/proc/device-tree/i2c@3180000/tca9546@70/i2c@0/imx274_a@1a";
+                };
+                drivernode1 {
+                    status = "okay";
+                    pcl_id = "v4l2_lens";
+                    proc-device-tree = "/proc/device-tree/lens_imx274@A6V26/";
+                };
+            };
+
+            module1 {
+                badge = "imx274_bottomright_A6V26";
+                position = "bottomright";
+                orientation = "0";
+                status = "okay";
+                drivernode0 {
+                status = "okay";
+                    pcl_id = "v4l2_sensor";
+                    devname = "imx274 31-001a";
+                    proc-device-tree = "/proc/device-tree/i2c@3180000/tca9546@70/i2c@1/imx274_b@1a";
+                };
+                drivernode1 {
+                status = "okay";
+                    pcl_id = "v4l2_lens";
+                    proc-device-tree = "/proc/device-tree/lens_imx274@A6V26/";
+                };
+            };
+
+            module2 {
+                badge = "imx274_centerleft_A6V26";
+                position = "centerleft";
+                orientation = "0";
+                status = "okay";
+                drivernode0 {
+                status = "okay";
+                    pcl_id = "v4l2_sensor";
+                    devname = "imx274 32-001a";
+                    proc-device-tree = "/proc/device-tree/i2c@3180000/tca9546@70/i2c@2/imx274_c@1a";
+                };
+                drivernode1 {
+                status = "okay";
+                    pcl_id = "v4l2_lens";
+                    proc-device-tree = "/proc/device-tree/lens_imx274@A6V26/";
+                };
+            };
+
+            module3 {
+                badge = "imx274_centerright_A6V26";
+                position = "centerright";
+                orientation = "0";
+                status = "okay";
+                drivernode0 {
+                    status = "okay";
+                    pcl_id = "v4l2_sensor";
+                    devname = "imx274 34-001a";
+                    proc-device-tree = "/proc/device-tree/i2c@c240000/tca9546@71/i2c@0/imx274_d@1a";
+                };
+                drivernode1 {
+                    status = "okay";
+                    pcl_id = "v4l2_lens";
+                    proc-device-tree = "/proc/device-tree/lens_imx274@A6V26/";
+                };
+            };
+
+            module4 {
+                badge = "imx274_topleft_A6V26";
+                position = "topleft";
+                orientation = "0";
+                status = "okay";
+                drivernode0 {
+                status = "okay";
+                    pcl_id = "v4l2_sensor";
+                    devname = "imx274 35-001a";
+                    proc-device-tree = "/proc/device-tree/i2c@c240000/tca9546@71/i2c@1/imx274_e@1a";
+                };
+                drivernode1 {
+                status = "okay";
+                    pcl_id = "v4l2_lens";
+                    proc-device-tree = "/proc/device-tree/lens_imx274@A6V26/";
+                };
+            };
+
+            module5 {
+                badge = "imx274_bottomleft_A6V26";
+                position = "bottomleft";
+                orientation = "0";
+                status = "okay";
+                drivernode0 {
+                status = "okay";
+                    pcl_id = "v4l2_sensor";
+                    devname = "imx274 36-001a";
+                    proc-device-tree = "/proc/device-tree/i2c@c240000/tca9546@71/i2c@2/imx274_f@1a";
+                };
+                drivernode1 {
+                status = "okay";
+                    pcl_id = "v4l2_lens";
+                    proc-device-tree = "/proc/device-tree/lens_imx274@A6V26/";
+                };
+            };
+        };
+    };
+};

--- a/nvidia/platform/t18x/quill/kernel-dts/tegra186-tx2-cti-ASG006-base.dts
+++ b/nvidia/platform/t18x/quill/kernel-dts/tegra186-tx2-cti-ASG006-base.dts
@@ -1,0 +1,259 @@
+#include <tegra186-tx2-cti-base.dts>
+
+/{
+    nvidia,dtsfilename = "tegra186-tx2-cti-ASG006-base.dts";
+
+    gpio@2200000 {
+    /*enable this to enabled PCIe Controller #2*/
+        pcie0_lane2_mux {
+             status = "okay";
+        };
+    /******************************************/
+    /*enable these two to enable USB3 Port 0*/
+        e3325_sdio_rst {
+           status = "disabled";
+        };
+        e3325_lane0_mux {
+            status = "disabled";
+        };
+    /******************************************/
+
+    };
+    i2c@3160000 {
+        gpio@74{    //Camera GPIO
+            status = "okay";
+            vcc-supply = <&battery_reg>;
+
+            /*PN - This is really bad practice to use gpio-hog to reserve the GPIOs
+            The driver should really request them properly, maybe fix this in the
+            future*/
+
+            camera-rst{
+                gpio-hog;
+                output-low;
+                gpios = <1 0 3 0 5 0 7 0>;
+                label = "cam_c_rst", "cam_d_rst", "cam_e_rst", "cam_f_rst";
+
+            };
+
+        };
+        gpio@77{
+            status = "okay";
+            vcc-supply = <&battery_reg>;
+        };
+
+    };
+
+
+
+    xhci@3530000 {
+        status = "okay";
+        phys = <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-0}>,
+            <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-1}>,
+            <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-2}>,
+            <&{/xusb_padctl@3520000/pads/usb3/lanes/usb3-1}>,
+            <&{/xusb_padctl@3520000/pads/usb3/lanes/usb3-2}>;
+        phy-names = "usb2-0", "usb2-1", "usb2-2", "usb3-1", "usb3-2";
+    };
+
+
+   xusb_padctl@3520000 {
+        pads {
+            usb2 {
+                lanes {
+                    usb2-0 {
+                        status = "okay";
+                    };
+                    usb2-1 {
+                        status = "okay";
+                    };
+                    usb2-2 {
+                        status = "okay";
+                    };
+                };
+            };
+            usb3 {
+                lanes {
+                    usb3-0 {
+                        status = "disabled";
+                    };
+                    usb3-1 {
+                        status = "okay";
+                    };
+                    usb3-2 {
+                        status = "okay";
+                    };
+                };
+            };
+        };
+        ports {
+            usb2-0 {
+                status = "okay";
+            };
+            usb2-1 {
+                status = "okay";
+            };
+
+            usb2-2 {
+                status = "okay";
+            };
+
+            usb3-0 {
+                nvidia,usb2-companion = <0>;
+                status = "disabled";
+            };
+            usb3-1 {
+                nvidia,usb2-companion = <1>;
+                status = "okay";
+            };
+            usb3-2 {
+                nvidia,usb2-companion = <2>;
+                status = "okay";
+            };
+        };
+    };
+    pinctrl@3520000 {
+        status = "okay";
+           pinmux {
+            usb2-port0 {
+                status = "okay";
+            };
+            usb2-port1 {
+                status = "okay";
+            };
+
+            usb2-port2 {
+                status = "okay";
+            };
+
+            usb3-port0 {
+                status = "disabled";
+            };
+
+            usb3-port1 {
+                status = "okay";
+            };
+
+            usb3-port2 {
+                status = "okay";
+            };
+        };
+    };
+    pcie-controller@10003000 {
+        pci@1,0 {
+            nvidia,num-lanes = <1>;
+            status = "okay";
+        };
+        pci@2,0 {
+            nvidia,num-lanes = <0>;
+            status = "disabled";
+        };
+        pci@3,0 {
+            nvidia,num-lanes = <1>;
+            status = "okay";
+        };
+    };
+
+   //needed for the cameras setup before including any camera dtsi
+    i2c@c240000 {
+        tca9546@71 {
+            compatible = "nxp,pca9544";
+            reg = <0x71>;
+            #address-cells = <1>;
+            vcc-supply = <&battery_reg>;
+            vcc-pullup-supply = <&battery_reg>;
+            #size-cells = <0>;
+            vif-supply = <&battery_reg>;
+            //skip_mux_detect = "yes";
+            skip_mux_detect = "no";
+            vcc_lp = "vif";
+            force_bus_start = <0x22>;   //34
+
+            i2c@0 {
+                reg = <0>;
+                i2c-mux,deselect-on-exit;
+                #address-cells = <1>;
+                #size-cells = <0>;
+            };
+            i2c@1 {
+                reg = <1>;
+                i2c-mux,deselect-on-exit;
+                #address-cells = <1>;
+                #size-cells = <0>;
+            };
+            i2c@2 {
+                reg = <2>;
+                i2c-mux,deselect-on-exit;
+                #address-cells = <1>;
+                #size-cells = <0>;
+            };
+        };
+    };
+
+   //needed for the cameras setup before including any camera dtsi
+    i2c@3180000 {
+
+        //get rid of the mux in the defautl device tree to eliminate conflicts
+        /delete-node/ i2cmux@70;
+
+        tca9546@70 {
+            compatible = "nxp,pca9544";
+            reg = <0x70>;
+            #address-cells = <1>;
+            #size-cells = <0>;
+            vcc-supply = <&battery_reg>;
+            vcc-pullup-supply = <&battery_reg>;
+            vif-supply = <&battery_reg>;
+            //skip_mux_detect = "yes";
+            skip_mux_detect = "no";
+            vcc_lp = "vif";
+            force_bus_start = <0x1e>;   //30
+
+            i2c@0 {
+                reg = <0>;
+                i2c-mux,deselect-on-exit;
+                #address-cells = <1>;
+                #size-cells = <0>;
+            };
+            i2c@1 {
+                reg = <1>;
+                i2c-mux,deselect-on-exit;
+                #address-cells = <1>;
+                #size-cells = <0>;
+            };
+            i2c@2 {
+                reg = <2>;
+                i2c-mux,deselect-on-exit;
+                #address-cells = <1>;
+                #size-cells = <0>;
+            };
+
+
+        };
+    };
+    spi@c260000 {
+        status = "okay";
+        /delete-node/ spi-touch-sharp19x12@0;
+        can@0 {
+            status = "okay";
+            compatible = "microchip,mcp2515";
+            reg = <0>;
+            clocks = <&can_clock>;
+            interrupt-parent = <&tegra_main_gpio>;
+                    /* the first cell defines the
+                        index of the interrupt within the controller, while the second cell is used
+                        to specify any of the following flags:
+                        - bits[3:0] trigger type and level flags
+                        1 = low-to-high edge triggered
+                        2 = high-to-low edge triggered
+                        4 = active high level-sensitive
+                        8 = active low level-sensitive
+                    */
+            interrupts = <TEGRA_MAIN_GPIO(I, 4) 0x2>;
+            vdd-supply = <&battery_reg>;
+            xceiver-supply = <&battery_reg>;
+            spi-max-frequency=<6375000>;
+       };
+    };
+
+};

--- a/nvidia/platform/t18x/quill/kernel-dts/tegra186-tx2-cti-ASG007.dts
+++ b/nvidia/platform/t18x/quill/kernel-dts/tegra186-tx2-cti-ASG007.dts
@@ -1,0 +1,179 @@
+#include <tegra186-tx2-cti-base.dts>
+
+/{
+    nvidia,dtsfilename = "tegra186-tx2-cti-ASG007.dts";
+
+    gpio@2200000 {
+    /*enable this to enabled PCIe Controller #2*/
+        pcie0_lane2_mux {
+             status = "okay";
+        };
+    /******************************************/
+    /*enable these two to enable USB3 Port 0*/
+        e3325_sdio_rst {
+           status = "disabled";
+        };
+        e3325_lane0_mux {
+            status = "disabled";
+        };
+    /******************************************/
+
+    };
+    i2c@3160000 {
+
+        gpio@74{
+            status = "disabled";
+
+
+        };
+        gpio@77{
+            status = "disabled";
+
+        };
+
+        gpio@20 {
+            compatible = "nxp,pca9534";
+            status = "okay";
+            reg = <0x20>;
+            gpio-controller;
+            #gpio-cells = <2>;
+            vcc-supply = <&battery_reg>;
+        };
+
+    };
+
+
+
+    xhci@3530000 {
+        status = "okay";
+        phys = <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-0}>,
+            <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-1}>,
+            <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-2}>,
+            <&{/xusb_padctl@3520000/pads/usb3/lanes/usb3-1}>;
+        phy-names = "usb2-0", "usb2-1", "usb2-2", "usb3-1";
+    };
+
+
+   xusb_padctl@3520000 {
+        pads {
+            usb2 {
+                lanes {
+                    usb2-0 {
+                        status = "okay";
+                    };
+                    usb2-1 {
+                        status = "okay";
+                    };
+                    usb2-2 {
+                        status = "okay";
+                    };
+                };
+            };
+            usb3 {
+                lanes {
+                    usb3-0 {
+                        status = "disabled";
+                    };
+                    usb3-1 {
+                        status = "okay";
+                    };
+                    usb3-2 {
+                        status = "disabled";
+                    };
+                };
+            };
+        };
+        ports {
+            usb2-0 {
+                status = "okay";
+            };
+            usb2-1 {
+                status = "okay";
+            };
+
+            usb2-2 {
+                status = "okay";
+            };
+
+            usb3-0 {
+                nvidia,usb2-companion = <0>;
+                status = "disabled";
+            };
+            usb3-1 {
+                nvidia,usb2-companion = <1>;
+                status = "okay";
+            };
+            usb3-2 {
+                nvidia,usb2-companion = <2>;
+                status = "disabled";
+            };
+        };
+    };
+    pinctrl@3520000 {
+        status = "okay";
+           pinmux {
+            usb2-port0 {
+                status = "okay";
+            };
+            usb2-port1 {
+                status = "okay";
+            };
+
+            usb2-port2 {
+                status = "okay";
+            };
+
+            usb3-port0 {
+                status = "disabled";
+            };
+
+            usb3-port1 {
+                status = "okay";
+            };
+
+            usb3-port2 {
+                status = "disabled";
+            };
+        };
+    };
+    pcie-controller@10003000 {
+        pci@1,0 {
+            nvidia,num-lanes = <2>;
+            status = "okay";
+        };
+        pci@2,0 {
+            nvidia,num-lanes = <1>;
+            status = "okay";
+        };
+        pci@3,0 {
+            nvidia,num-lanes = <1>;
+            status = "okay";
+        };
+    };
+    spi@c260000 {
+        status = "okay";
+        /delete-node/ spi-touch-sharp19x12@0;
+        can@0 {
+            status = "okay";
+            compatible = "microchip,mcp2515";
+            reg = <0>;
+            clocks = <&can_clock>;
+            interrupt-parent = <&tegra_main_gpio>;
+                /* the first cell defines the
+                    index of the interrupt within the controller, while the second cell is used
+                    to specify any of the following flags:
+                    - bits[3:0] trigger type and level flags
+                    1 = low-to-high edge triggered
+                    2 = high-to-low edge triggered
+                    4 = active high level-sensitive
+                    8 = active low level-sensitive
+                */
+          interrupts = <TEGRA_MAIN_GPIO(I, 4) 0x2>;
+          vdd-supply = <&battery_reg>;
+          xceiver-supply = <&battery_reg>;
+          spi-max-frequency=<6375000>;
+       };
+    };
+
+
+};

--- a/nvidia/platform/t18x/quill/kernel-dts/tegra186-tx2-cti-ASG008-base.dts
+++ b/nvidia/platform/t18x/quill/kernel-dts/tegra186-tx2-cti-ASG008-base.dts
@@ -1,0 +1,158 @@
+#include <tegra186-tx2-cti-base.dts>
+
+/{
+    nvidia,dtsfilename = "tegra186-tx2-cti-ASG008-base.dts";
+
+    gpio@2200000 {
+    /*enable this to enabled PCIe Controller #2*/
+        pcie0_lane2_mux {
+             status = "okay";
+        };
+    /******************************************/
+    /*enable these two to enable USB3 Port 0*/
+        e3325_sdio_rst {
+           status = "disabled";
+        };
+        e3325_lane0_mux {
+            status = "disabled";
+        };
+    /******************************************/
+
+    };
+
+
+
+    xhci@3530000 {
+        status = "okay";
+        phys = <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-0}>,
+            <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-1}>,
+            <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-2}>;
+        phy-names = "usb2-0", "usb2-1", "usb2-2";
+    };
+
+    /*Disable HDMI out for sprocket*/
+    host1x{
+        sor1 {
+            status = "okay";    //leave this enabled
+            hdmi-display {
+                status = "disabled";
+            };
+        };
+    };
+
+
+    i2c@3160000 {
+
+        gpio@74{
+            status = "disabled";
+
+
+        };
+        gpio@77{
+            status = "disabled";
+
+        };
+
+    };
+
+
+
+   xusb_padctl@3520000 {
+        pads {
+            usb2 {
+                lanes {
+                    usb2-0 {
+                        status = "okay";
+                    };
+                    usb2-1 {
+                        status = "okay";
+                    };
+                    usb2-2 {
+                        status = "okay";
+                    };
+                };
+            };
+            usb3 {
+                lanes {
+                    usb3-0 {
+                        status = "disabled";
+                    };
+                    usb3-1 {
+                        status = "disabled";
+                    };
+                    usb3-2 {
+                        status = "disabled";
+                    };
+                };
+            };
+        };
+        ports {
+            usb2-0 {
+                status = "okay";
+            };
+            usb2-1 {
+                status = "okay";
+            };
+
+            usb2-2 {
+                status = "okay";
+            };
+
+            usb3-0 {
+                nvidia,usb2-companion = <0>;
+                status = "disabled";
+            };
+            usb3-1 {
+                nvidia,usb2-companion = <1>;
+                status = "disabled";
+            };
+            usb3-2 {
+                nvidia,usb2-companion = <2>;
+                status = "disabled";
+            };
+        };
+    };
+    pinctrl@3520000 {
+        status = "okay";
+           pinmux {
+            usb2-port0 {
+                status = "okay";
+            };
+            usb2-port1 {
+                status = "okay";
+            };
+
+            usb2-port2 {
+                status = "okay";
+            };
+
+            usb3-port0 {
+                status = "disabled";
+            };
+
+            usb3-port1 {
+                status = "disabled";
+            };
+
+            usb3-port2 {
+                status = "disabled";
+            };
+        };
+    };
+    pcie-controller@10003000 {
+        pci@1,0 {
+            nvidia,num-lanes = <1>;
+            status = "disabled";
+        };
+        pci@2,0 {
+            nvidia,num-lanes = <0>;
+            status = "disabled";
+        };
+        pci@3,0 {
+            nvidia,num-lanes = <1>;
+            status = "disabled";
+        };
+    };
+
+
+};

--- a/nvidia/platform/t18x/quill/kernel-dts/tegra186-tx2-cti-ESG503-USB3.dts
+++ b/nvidia/platform/t18x/quill/kernel-dts/tegra186-tx2-cti-ESG503-USB3.dts
@@ -1,0 +1,187 @@
+#include <tegra186-tx2-cti-base.dts>
+
+/{
+    nvidia,dtsfilename = "tegra186-tx2-cti-ESG503-USB3.dts";
+
+    gpio@2200000 {
+    /*enable this to enabled PCIe Controller #2*/
+        pcie0_lane2_mux {
+             status = "disabled";
+        };
+    /******************************************/
+    /*enable these two to enable USB3 Port 0*/
+        e3325_sdio_rst {
+           status = "okay";
+        };
+        e3325_lane0_mux {
+            status = "okay";
+        };
+    /******************************************/
+
+    };
+    i2c@3160000 {
+
+        gpio@74{
+            status = "disabled";
+
+
+        };
+        gpio@77{
+            status = "disabled";
+
+        };
+
+    };
+
+    i2c@c240000{
+        #address-cells = <1>;
+        #size-cells = <0>;
+
+        gpio@74{
+            compatible = "ti,tca9539";
+            reg = <0x74>;
+            gpio-controller;
+            #gpio-cells = <0x2>;
+            vcc-supply = <&battery_reg>;
+            status = "okay";
+         };
+
+    };
+    spi@c260000 {
+        status = "okay";
+        /delete-node/ spi-touch-sharp19x12@0;
+        can@0 {
+            status = "okay";
+            compatible = "microchip,mcp2515";
+            reg = <0>;
+            clocks = <&can_clock>;
+            interrupt-parent = <&tegra_main_gpio>;
+                /* the first cell defines the
+                    index of the interrupt within the controller, while the second cell is used
+                    to specify any of the following flags:
+                    - bits[3:0] trigger type and level flags
+                    1 = low-to-high edge triggered
+                    2 = high-to-low edge triggered
+                    4 = active high level-sensitive
+                    8 = active low level-sensitive
+                */
+          interrupts = <TEGRA_MAIN_GPIO(I, 4) 0x2>;
+          vdd-supply = <&battery_reg>;
+          xceiver-supply = <&battery_reg>;
+          spi-max-frequency=<6375000>;
+       };
+    };
+
+
+
+    xhci@3530000 {
+        status = "okay";
+        phys = <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-0}>,
+            <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-1}>,
+            <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-2}>,
+            <&{/xusb_padctl@3520000/pads/usb3/lanes/usb3-0}>,
+            <&{/xusb_padctl@3520000/pads/usb3/lanes/usb3-2}>;
+        phy-names = "usb2-0", "usb2-1", "usb2-2", "usb3-0", "usb3-2";
+    };
+
+
+   xusb_padctl@3520000 {
+        pads {
+            usb2 {
+                lanes {
+                    usb2-0 {
+                        status = "okay";
+                    };
+                    usb2-1 {
+                        status = "okay";
+                    };
+                    usb2-2 {
+                        status = "okay";
+                    };
+                };
+            };
+            usb3 {
+                lanes {
+                    usb3-0 {
+                        status = "okay";
+                    };
+                    usb3-1 {
+                        
+                        status = "disabled";
+                    };
+                    usb3-2 {
+                        status = "okay";
+                    };
+                };
+            };
+        };
+        ports {
+            usb2-0 {
+                status = "okay";
+            };
+            usb2-1 {
+                status = "okay";
+            };
+
+            usb2-2 {
+                status = "okay";
+            };
+
+            usb3-0 {
+                nvidia,usb2-companion = <0>;
+                status = "okay";
+            };
+            usb3-1 {
+                nvidia,usb2-companion = <1>;
+                status = "disabled";
+            };
+            usb3-2 {
+                nvidia,usb2-companion = <2>;
+                status = "okay";
+            };
+        };
+    };
+    pinctrl@3520000 {
+        status = "okay";
+           pinmux {
+            usb2-port0 {
+                status = "okay";
+            };
+            usb2-port1 {
+                status = "okay";
+            };
+
+            usb2-port2 {
+                status = "okay";
+            };
+
+            usb3-port0 {
+                status = "okay";
+            };
+
+            usb3-port1 {
+                status = "disabled";
+            };
+
+            usb3-port2 {
+                status = "okay";
+            };
+        };
+    };
+    pcie-controller@10003000 {
+        pci@1,0 {
+            nvidia,num-lanes = <1>;
+            status = "okay";
+        };
+        pci@2,0 {
+            nvidia,num-lanes = <0>;
+            status = "disabled";
+        };
+        pci@3,0 {
+            nvidia,num-lanes = <1>;
+            status = "okay";
+        };
+    };
+
+
+};

--- a/nvidia/platform/t18x/quill/kernel-dts/tegra186-tx2-cti-ESG503-mPCIe.dts
+++ b/nvidia/platform/t18x/quill/kernel-dts/tegra186-tx2-cti-ESG503-mPCIe.dts
@@ -1,0 +1,186 @@
+#include <tegra186-tx2-cti-base.dts>
+
+/{
+    nvidia,dtsfilename = "tegra186-tx2-cti-ESG503-mPCIe.dts";
+
+    gpio@2200000 {
+    /*enable this to enabled PCIe Controller #2*/
+        pcie0_lane2_mux {
+             status = "okay";
+        };
+    /******************************************/
+    /*enable these two to enable USB3 Port 0*/
+        e3325_sdio_rst {
+           status = "disabled";
+        };
+        e3325_lane0_mux {
+            status = "disabled";
+        };
+    /******************************************/
+
+    };
+    i2c@3160000 {
+
+        gpio@74{
+            status = "disabled";
+
+
+        };
+        gpio@77{
+            status = "disabled";
+
+        };
+
+    };
+
+    i2c@c240000{
+        #address-cells = <1>;
+        #size-cells = <0>;
+
+        gpio@74{
+            compatible = "ti,tca9539";
+            reg = <0x74>;
+            gpio-controller;
+            #gpio-cells = <0x2>;
+            vcc-supply = <&battery_reg>;
+            status = "okay";
+         };
+
+    };
+    spi@c260000 {
+        status = "okay";
+        /delete-node/ spi-touch-sharp19x12@0;
+        can@0 {
+            status = "okay";
+            compatible = "microchip,mcp2515";
+            reg = <0>;
+            clocks = <&can_clock>;
+            interrupt-parent = <&tegra_main_gpio>;
+                /* the first cell defines the
+                    index of the interrupt within the controller, while the second cell is used
+                    to specify any of the following flags:
+                    - bits[3:0] trigger type and level flags
+                    1 = low-to-high edge triggered
+                    2 = high-to-low edge triggered
+                    4 = active high level-sensitive
+                    8 = active low level-sensitive
+                */
+          interrupts = <TEGRA_MAIN_GPIO(I, 4) 0x2>;
+          vdd-supply = <&battery_reg>;
+          xceiver-supply = <&battery_reg>;
+          spi-max-frequency=<6375000>;
+       };
+    };
+
+
+
+    xhci@3530000 {
+        status = "okay";
+        phys = <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-0}>,
+            <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-1}>,
+            <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-2}>,
+            <&{/xusb_padctl@3520000/pads/usb3/lanes/usb3-1}>,
+            <&{/xusb_padctl@3520000/pads/usb3/lanes/usb3-2}>;
+        phy-names = "usb2-0", "usb2-1", "usb2-3", "usb3-1", "usb3-2";
+    };
+
+
+   xusb_padctl@3520000 {
+        pads {
+            usb2 {
+                lanes {
+                    usb2-0 {
+                        status = "okay";
+                    };
+                    usb2-1 {
+                        status = "okay";
+                    };
+                    usb2-2 {
+                        status = "okay";
+                    };
+                };
+            };
+            usb3 {
+                lanes {
+                    usb3-0 {
+                        status = "disabled";
+                    };
+                    usb3-1 {
+                        status = "okay";
+                    };
+                    usb3-2 {
+                        status = "okay";
+                    };
+                };
+            };
+        };
+        ports {
+            usb2-0 {
+                status = "okay";
+            };
+            usb2-1 {
+                status = "okay";
+            };
+
+            usb2-2 {
+                status = "okay";
+            };
+
+            usb3-0 {
+                nvidia,usb2-companion = <0>;
+                status = "disabled";
+            };
+            usb3-1 {
+                nvidia,usb2-companion = <1>;
+                status = "okay";
+            };
+            usb3-2 {
+                nvidia,usb2-companion = <2>;
+                status = "okay";
+            };
+        };
+    };
+    pinctrl@3520000 {
+        status = "okay";
+           pinmux {
+            usb2-port0 {
+                status = "okay";
+            };
+            usb2-port1 {
+                status = "okay";
+            };
+
+            usb2-port2 {
+                status = "okay";
+            };
+
+            usb3-port0 {
+                status = "disabled";
+            };
+
+            usb3-port1 {
+                status = "okay";
+            };
+
+            usb3-port2 {
+                status = "okay";
+            };
+        };
+    };
+    pcie-controller@10003000 {
+        pci@1,0 {
+            nvidia,num-lanes = <1>;
+            status = "okay";
+        };
+        pci@2,0 {
+            nvidia,num-lanes = <0>;
+            status = "disabled";
+        };
+        pci@3,0 {
+            nvidia,num-lanes = <1>;
+            status = "okay";
+        };
+    };
+
+
+};

--- a/nvidia/platform/t18x/quill/kernel-dts/tegra186-tx2-cti-ESG503.dts
+++ b/nvidia/platform/t18x/quill/kernel-dts/tegra186-tx2-cti-ESG503.dts
@@ -1,0 +1,187 @@
+#include <tegra186-tx2-cti-base.dts>
+
+/{
+    nvidia,dtsfilename = "tegra186-tx2-cti-ESG503.dts";
+
+    gpio@2200000 {
+    /*enable this to enabled PCIe Controller #2*/
+        pcie0_lane2_mux {
+             status = "okay";
+        };
+    /******************************************/
+    /*enable these two to enable USB3 Port 0*/
+        e3325_sdio_rst {
+           status = "disabled";
+        };
+        e3325_lane0_mux {
+            status = "disabled";
+        };
+    /******************************************/
+
+    };
+
+    i2c@3160000 {
+
+        gpio@74{
+            status = "disabled";
+
+
+        };
+        gpio@77{
+            status = "disabled";
+
+        };
+
+    };
+    i2c@c240000{
+        #address-cells = <1>;
+        #size-cells = <0>;
+
+        gpio@74{
+            compatible = "ti,tca9539";
+            reg = <0x74>;
+            gpio-controller;
+            #gpio-cells = <0x2>;
+            vcc-supply = <&battery_reg>;
+            status = "okay";
+         };
+
+    };
+
+
+    xhci@3530000 {
+        status = "okay";
+        phys = <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-0}>,
+            <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-1}>,
+            <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-2}>,
+            <&{/xusb_padctl@3520000/pads/usb3/lanes/usb3-1}>,
+            <&{/xusb_padctl@3520000/pads/usb3/lanes/usb3-2}>;
+        phy-names = "usb2-0", "usb2-1", "usb2-2", "usb3-1", "usb3-2";
+    };
+
+
+   xusb_padctl@3520000 {
+        pads {
+            usb2 {
+                lanes {
+                    usb2-0 {
+                        status = "okay";
+                    };
+                    usb2-1 {
+                        status = "okay";
+                    };
+                    usb2-2 {
+                        status = "okay";
+                    };
+                };
+            };
+            usb3 {
+                lanes {
+                    usb3-0 {
+                        status = "disabled";
+                    };
+                    usb3-1 {
+                        status = "okay";
+                    };
+                    usb3-2 {
+                        status = "okay";
+                    };
+                };
+            };
+        };
+        ports {
+            usb2-0 {
+                status = "okay";
+            };
+            usb2-1 {
+                status = "okay";
+            };
+
+            usb2-2 {
+                status = "okay";
+            };
+
+            usb3-0 {
+                nvidia,usb2-companion = <0>;
+                status = "disabled";
+            };
+            usb3-1 {
+                nvidia,usb2-companion = <1>;
+                status = "okay";
+            };
+            usb3-2 {
+                nvidia,usb2-companion = <2>;
+                status = "okay";
+            };
+        };
+    };
+    pinctrl@3520000 {
+        status = "okay";
+           pinmux {
+            usb2-port0 {
+                status = "okay";
+            };
+            usb2-port1 {
+                status = "okay";
+            };
+
+            usb2-port2 {
+                status = "okay";
+            };
+
+            usb3-port0 {
+                status = "disabled";
+            };
+
+            usb3-port1 {
+                status = "okay";
+            };
+
+            usb3-port2 {
+                status = "okay";
+            };
+        };
+    };
+    pcie-controller@10003000 {
+        pci@1,0 {
+            nvidia,num-lanes = <1>;
+            status = "okay";
+        };
+        pci@2,0 {
+            nvidia,num-lanes = <0>;
+            status = "disabled";
+        };
+        pci@3,0 {
+            nvidia,num-lanes = <1>;
+            status = "okay";
+        };
+    };
+
+    spi@c260000 {
+         status = "okay";      
+        /delete-node/ spi-touch-sharp19x12@0; 
+       
+        can@0 {
+            status = "okay";
+            compatible = "microchip,mcp2515";
+            reg = <0>;
+            clocks = <&can_clock>;
+            interrupt-parent = <&tegra_main_gpio>;
+                /* the first cell defines the
+                    index of the interrupt within the controller, while the second cell is used
+                    to specify any of the following flags:
+                    - bits[3:0] trigger type and level flags
+                    1 = low-to-high edge triggered
+                    2 = high-to-low edge triggered
+                    4 = active high level-sensitive
+                    8 = active low level-sensitive
+                */
+          interrupts = <TEGRA_MAIN_GPIO(I, 4) 0x2>;
+          vdd-supply = <&battery_reg>;
+          xceiver-supply = <&battery_reg>;
+          spi-max-frequency=<6375000>;
+       };
+    };
+
+
+};

--- a/nvidia/platform/t18x/quill/kernel-dts/tegra186-tx2-cti-VPG003.dts
+++ b/nvidia/platform/t18x/quill/kernel-dts/tegra186-tx2-cti-VPG003.dts
@@ -1,0 +1,133 @@
+#include <tegra186-tx2-cti-base.dts>
+
+/{
+    nvidia,dtsfilename = "tegra186-tx2-cti-VPG003.dts";
+
+    gpio@2200000 {
+    /*enable this to enabled PCIe Controller #2*/
+        pcie0_lane2_mux {
+             status = "disable";
+        };
+    /******************************************/
+    /*enable these two to enable USB3 Port 0*/
+        e3325_sdio_rst {
+           status = "okay";
+        };
+        e3325_lane0_mux {
+            status = "okay";
+        };
+    /******************************************/
+
+    };
+
+
+
+    xhci@3530000 {
+        status = "okay";
+        phys = <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-0}>,
+            <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-1}>,
+            <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-2}>,
+            <&{/xusb_padctl@3520000/pads/usb3/lanes/usb3-0}>;
+        phy-names = "usb2-0", "usb2-1", "usb2-2", "usb3-0";
+    };
+
+
+   xusb_padctl@3520000 {
+        pads {
+            usb2 {
+                lanes {
+                    usb2-0 {
+                        status = "okay";
+                    };
+                    usb2-1 {
+                        status = "okay";
+                    };
+                    usb2-2 {
+                        status = "okay";
+                    };
+                };
+            };
+            usb3 {
+                lanes {
+                    usb3-0 {
+                        status = "okay";
+                    };
+                    usb3-1 {
+                        status = "disabled";
+                    };
+                    usb3-2 {
+                        status = "disabled";
+                    };
+                };
+            };
+        };
+        ports {
+            usb2-0 {
+                status = "okay";
+            };
+            usb2-1 {
+                status = "okay";
+            };
+
+            usb2-2 {
+                status = "okay";
+            };
+
+            usb3-0 {
+                nvidia,usb2-companion = <0>;
+                status = "okay";
+            };
+            usb3-1 {
+                nvidia,usb2-companion = <1>;
+                status = "disabled";
+            };
+            usb3-2 {
+                nvidia,usb2-companion = <2>;
+                status = "disabled";
+            };
+        };
+    };
+    pinctrl@3520000 {
+        status = "okay";
+           pinmux {
+            usb2-port0 {
+                status = "okay";
+            };
+            usb2-port1 {
+                status = "okay";
+            };
+
+            usb2-port2 {
+                status = "okay";
+            };
+
+            usb3-port0 {
+                status = "okay";
+            };
+
+            usb3-port1 {
+                status = "disabled";
+            };
+
+            usb3-port2 {
+                status = "disabled";
+            };
+        };
+    };
+    pcie-controller@10003000 {
+        pci@1,0 {
+            nvidia,num-lanes = <4>;
+            status = "okay";
+        };
+        pci@2,0 {
+            nvidia,num-lanes = <0>;
+            status = "disabled";
+        };
+        pci@3,0 {
+            nvidia,num-lanes = <1>;
+            status = "okay";
+        };
+    };
+
+
+};

--- a/nvidia/platform/t18x/quill/kernel-dts/tegra186-tx2-cti-audio-ASG001.dtsi
+++ b/nvidia/platform/t18x/quill/kernel-dts/tegra186-tx2-cti-audio-ASG001.dtsi
@@ -1,0 +1,62 @@
+
+/* Astro FSL SGTL5000 Audio code support */
+
+#include <dt-bindings/types.h>
+#include <dt-bindings/gpio/tegra186-gpio.h>
+
+/ {
+        
+    i2c@c240000 {
+        sgtl5000_codec: sgtl5000@0a {
+            status = "okay";
+            compatible = "fsl,sgtl5000";
+            reg = <0x0a>;
+            clocks=<&tegra_car TEGRA186_CLK_AUD_MCLK>;
+            VDDA-supply=<&vdd_1v8_ap>;
+            VDDIO-supply = <&vdd_1v8_ap>;
+            VDDD-supply = <&vdd_1v8_ap>;
+        }; 
+    };
+       
+	tegra_sound: sound {
+		nvidia,num-codec-link = <11>;
+		status = "okay";
+        
+		nvidia,audio-routing =
+            "x Headphone Jack", "x HP_OUT",
+            "x Line In Jack", "x LINE_IN", 
+            "x Mic Jack", "x MIC_IN",
+			"y Headphone",		"y OUT",
+			"y IN",			"y Mic",
+			"z Headphone",		"z OUT",
+			"z IN",			"z Mic",
+			"m Headphone",		"m OUT",
+			"m IN",			"m Mic",
+			"n Headphone",		"n OUT",
+			"n IN",			"n Mic",
+			"o Headphone",		"o OUT",
+			"o IN",			"o Mic",
+			"a IN",			"a Mic",
+			"b IN",			"b Mic",
+			"c IN",			"c Mic",
+			"d IN",			"d Mic",
+			"e Headphone",		"e OUT",
+			"e IN",			"e Mic",
+			"d1 Headphone",		"d1 OUT",
+			"d2 Headphone",		"d2 OUT";
+
+            
+		rt565x_dai_link: nvidia,dai-link-1 {
+			link-name = "sgtl5000-playback";
+			codec-dai = <&sgtl5000_codec>;
+			codec-dai-name = "sgtl5000";
+			status = "okay";
+		};
+		nvidia,dai-link-12 {
+			status = "disabled";
+		};
+		nvidia,dai-link-13 {
+			status = "disabled";
+        };
+	};
+};

--- a/nvidia/platform/t18x/quill/kernel-dts/tegra186-tx2-cti-base.dts
+++ b/nvidia/platform/t18x/quill/kernel-dts/tegra186-tx2-cti-base.dts
@@ -1,0 +1,283 @@
+/*
+ * tegra186-quill-p3310-c03-00-base.dts Quill C03 Board
+ *
+ * Copyright (c) 2016-2018, NVIDIA CORPORATION. All rights reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; version 2 of the License.
+ *
+ * This program is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for
+ * more details.
+ */
+#include <t18x-common-platforms/tegra186-quill-common-p3310-1000-a00.dtsi>
+//#include <t18x-common-platforms/tegra186-quill-power-tree-p3310-1000-a00-00.dtsi>
+#include <t18x-common-platforms/tegra186-tx2-cti-power-tree.dtsi>
+//#include <t18x-common-platforms/tegra186-quill-camera-modules.dtsi>
+#include <t18x-common-modules/tegra186-display-e3320-1000-a00.dtsi>
+
+
+/* comms dtsi file should be included after gpio dtsi file */
+#include <t18x-common-platforms/tegra186-quill-comms.dtsi>
+#include <t18x-common-plugin-manager/tegra186-tx2-cti-plugin-manager.dtsi>
+//#include <t18x-common-modules/tegra186-super-module-e2614-p2597-1000-a00.dtsi>
+#include <t18x-common-plugin-manager/tegra186-quill-display-plugin-manager.dtsi>
+#include <t18x-common-prod/tegra186-priv-quill-p3310-1000-a00-prod.dtsi>
+//#include <t18x-common-plugin-manager/tegra186-quill-camera-plugin-manager.dtsi>
+#include "tegra186-tx2-cti-usb-pcie-base.dtsi"
+
+/ {
+    model = "quill";
+    compatible = "nvidia,quill", "nvidia,tegra186";
+
+    nvidia,boardids = "3310:0000:C03";
+    nvidia,proc-boardid = "3310:0000:C03";
+
+	nvidia,dtsfilename = __FILE__;
+	nvidia,dtbbuildtime = __DATE__, __TIME__;
+	nvidia,fastboot-usb-vid = <0x0955>;
+	nvidia,fastboot-usb-pid = <0xee16>;
+
+    chosen {
+        board-has-eeprom;
+        bootargs ="console=ttyS0,115200 androidboot.presilicon=true firmware_class.path=/etc/firmware";
+        stdout-path = &uarta;
+    };
+
+    firmware {
+        android {
+            compatible = "android,firmware";
+            hardware = "quill";
+            vbmeta {
+                compatible = "android,vbmeta";
+                parts = "vbmeta,kernel,kernel-dtb,kernel-dtbo,APP,vendor,SOS";
+            };
+            fstab {
+                compatible = "android,fstab";
+                vendor {
+                    compatible = "android,vendor";
+                    dev = "/dev/block/platform/3460000.sdhci/by-name/vendor";
+                    type = "ext4";
+                    mnt_flags = "ro";
+                    fsmgr_flags = "wait,avb";
+                };
+                odm {
+                    compatible = "android,odm";
+                    dev = "/dev/block/platform/3460000.sdhci/by-name/odm";
+                    type = "ext4";
+                    mnt_flags = "ro";
+                    fsmgr_flags = "wait,avb";
+                };
+            };
+        };
+    };
+
+    memory@80000000 {
+        device_type = "memory";
+        reg = <0x0 0x80000000 0x0 0x70000000>;
+    };
+
+    i2c@3160000 {
+
+        gpio@74{
+            status = "disabled";
+
+
+        };
+        gpio@77{
+            status = "disabled";
+
+        };
+
+        lp8557-backlight-s-wuxga-8-0@2c {
+            status = "disabled";
+        };
+    };
+
+    i2c@c240000 {
+        clock-frequency = <400000>;
+    };
+
+    cpus {
+        status = "disabled";
+    };
+    host1x {
+        sor {
+            status = "disabled";
+            dp-display {
+                status = "disabled";
+            };
+            hdmi-display {
+                status = "disabled";
+            };
+
+            panel-s-edp-uhdtv-15-6 {
+                smartdimmer {
+                    status = "disabled";
+                };
+            };
+        };
+
+        dpaux@155c0000 {
+            status = "disabled";
+        };
+
+        sor1 {
+            status = "okay";
+            nvidia,active-panel = <&sor1_hdmi_display>;
+            hdmi-display {
+                status = "okay";
+            };
+            dp-display {
+                status = "disabled";
+            };
+        };
+
+        nvdisplay@15200000 {
+            status = "disabled";
+        };
+
+        nvdisplay@15220000 {
+            status = "disabled";
+        };
+    };
+
+
+	pinmux@2430000 {
+		common {
+			gpio_edp2_pp5 {
+				status = "okay";
+			};
+
+			gpio_edp3_pp6 {
+				status = "okay";
+			};
+		};
+	};
+
+	gpio@2200000 {
+		sdmmc-wake-support-input {
+			status = "okay";
+		};
+
+		sdmmc-wake-support-output {
+			status = "okay";
+		};
+	};
+
+
+	sdhci@3400000 {
+		cd-gpios = <&tegra_main_gpio TEGRA_MAIN_GPIO(P, 5) 0>;
+		nvidia,cd-wakeup-capable;
+	};
+
+/*	i2c@3160000 {
+        /delete-node/ ina3221x@40;
+		/delete-node/ ina3221x@41;
+
+	};*/
+
+	i2c@c240000 {
+		bmi160@69 {
+			compatible = "bmi,bmi160";
+			reg = <0x69>;
+			interrupt-parent = <&tegra_aon_gpio>;
+			interrupts = <TEGRA_AON_GPIO(AA, 2) 0x01>;
+			accelerometer_matrix    = [01 00 00 00 01 00 00 00 01];
+			gyroscope_matrix        = [01 00 00 00 01 00 00 00 01];
+			accelerometer_delay_us_min = <1250>;
+			gyroscope_delay_us_min = <1250>;
+			vdd-supply = <&spmic_sd3>;
+			vdd_IO-supply = <&spmic_sd3>;
+			status = "disabled";
+		};
+	};
+
+	mttcan@c310000 {
+		status = "disabled";
+		gpio_can_stb = <&tegra_aon_gpio TEGRA_AON_GPIO(AA, 0) GPIO_ACTIVE_HIGH>;
+		gpio_can_en = <&tegra_aon_gpio TEGRA_AON_GPIO(AA, 1) GPIO_ACTIVE_HIGH>;
+		mram-params = <0 16 16 8 8 8 16 16 16>;
+		tx-config = <8 8 0 64>;
+		rx-config = <64 64 64>;
+	};
+
+	mttcan@c320000 {
+		status = "disabled";
+		gpio_can_stb = <&tegra_aon_gpio TEGRA_AON_GPIO(AA, 6) GPIO_ACTIVE_HIGH>;
+		gpio_can_en = <&tegra_aon_gpio TEGRA_AON_GPIO(AA, 7) GPIO_ACTIVE_HIGH>;
+		mram-params = <0 16 16 8 8 8 16 16 16>;
+		tx-config = <8 8 0 64>;
+		rx-config = <64 64 64>;
+	};
+
+	ahci-sata@3507000 {
+		gpios = <&spmic 7 0>;
+	};
+
+
+    bluedroid_pm {
+        bluedroid_pm,reset-gpio = <&tegra_main_gpio TEGRA_MAIN_GPIO(H, 5) 0>;
+    };
+
+	fixed-regulators {
+		regulator@1 {
+			gpio = <&tegra_main_gpio TEGRA_MAIN_GPIO(P, 6) 0>;
+                };
+	};
+
+	bpmp_i2c {
+		spmic@3c {
+			pinmux@0 {
+				pin_gpio2 {
+					status = "disabled";
+				};
+				pin_gpio3 {
+					status = "disabled";
+				};
+				pin_gpio7 {
+					drive-push-pull = <1>;
+				};
+			};
+
+			regulators {
+				ldo0 {
+					maxim,active-fps-source = <MAX77620_FPS_SRC_NONE>;
+				};
+
+				ldo6 {
+					maxim,active-fps-source = <MAX77620_FPS_SRC_NONE>;
+					regulator-boot-on;
+					regulator-always-on;
+				};
+
+				ldo7 {
+					regulator-min-microvolt = <1000000>;
+					regulator-max-microvolt = <1000000>;
+				};
+
+				ldo8 {
+					regulator-name = "dvdd-pex";
+					regulator-min-microvolt = <1000000>;
+					regulator-max-microvolt = <1000000>;
+				};
+			};
+		};
+	};
+    can_clock: can_clock{
+        compatible = "fixed-clock";
+        #clock-cells = <0>;
+        clock-frequency = <20000000>;
+        clock-accuracy = <100>;
+    };
+
+
+
+};
+
+#if LINUX_VERSION >= 414
+#include <tegra186-linux-4.14.dtsi>
+#endif
+                   

--- a/nvidia/platform/t18x/quill/kernel-dts/tegra186-tx2-cti-usb-pcie-base.dtsi
+++ b/nvidia/platform/t18x/quill/kernel-dts/tegra186-tx2-cti-usb-pcie-base.dtsi
@@ -1,0 +1,220 @@
+
+
+/{
+
+    gpio@2200000 {
+    /*enable this to enabled PCIe Controller #2*/
+        pcie0_lane2_mux {
+             status = "okay";
+        };
+    /******************************************/
+    /*enable these two to enable USB3 Port 0*/
+        e3325_sdio_rst {
+           status = "disabled";
+        };
+        e3325_lane0_mux {
+            status = "disabled";
+        };
+    /******************************************/
+
+    };
+
+
+    usb_cd {
+        status = "okay";
+        phys = <&tegra_xusb_padctl TEGRA_PADCTL_PHY_UTMI_P(0)>;
+
+        phy-names = "otg-phy";
+    };
+
+    xotg {
+        status = "okay";
+        phys = <&tegra_xusb_padctl TEGRA_PADCTL_PHY_UTMI_P(0)>;
+        phy-names = "otg-usb2";
+    };
+
+    xudc@3550000 {
+        status = "okay";
+        phys = <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-0}>;
+        phy-names = "usb2";
+        nvidia,boost-cpu-freq = <1200>;
+    };
+
+    usb_cd {
+        status = "okay";
+        phys = <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-0}>;
+        phy-names = "otg-phy";
+        nvidia,xusb-padctl = <&xusb_padctl>;
+    };
+
+    xhci@3530000 {
+        status = "okay";
+        phys = <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-0}>,
+            <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-1}>,
+            <&{/xusb_padctl@3520000/pads/usb2/lanes/usb2-2}>,
+            <&{/xusb_padctl@3520000/pads/usb3/lanes/usb3-0}>,
+            <&{/xusb_padctl@3520000/pads/usb3/lanes/usb3-1}>,
+            <&{/xusb_padctl@3520000/pads/usb3/lanes/usb3-2}>;
+        phy-names = "usb2-0", "usb2-1", "usb2-2", "usb3-0", "usb3-1", "usb3-0";
+    };
+
+
+    xusb_padctl@3520000 {
+        status = "okay";
+        pinctrl-0 = <&vbus_en0_default_state>;
+        pinctrl-1 = <&vbus_en1_default_state>;
+        pinctrl-2 = <&vbus_en0_sfio_tristate_state>;
+        pinctrl-3 = <&vbus_en1_sfio_tristate_state>;
+        pinctrl-4 = <&vbus_en0_sfio_passthrough_state>;
+        pinctrl-5 = <&vbus_en1_sfio_passthrough_state>;
+        pinctrl-names = "vbus_en0_default", "vbus_en1_default",
+            "vbus_en0_sfio_tristate", "vbus_en1_sfio_tristate",
+            "vbus_en0_sfio_passthrough", "vbus_en1_sfio_passthrough";
+
+        pads {
+            usb2 {
+                lanes {
+                    usb2-0 {
+                        nvidia,function = "xusb";
+                        status = "disabled";
+                    };
+                    usb2-1 {
+                        nvidia,function = "xusb";
+                        status = "disabled";
+                    };
+                    usb2-2 {
+                        nvidia,function = "xusb";
+                        status = "disabled";
+                    };
+                };
+            };
+            usb3 {
+                lanes {
+                    usb3-0 {
+                        nvidia,function = "xusb";
+                        status = "disabled";
+                    };
+                    usb3-1 {
+                        nvidia,function = "xusb";
+                        status = "disabled";
+                    };
+                    usb3-2 {
+                        nvidia,function = "xusb";
+                        status = "disabled";
+                    };
+                };
+            };
+        };
+        ports {
+            usb2-0 {
+
+                mode = "otg";
+                vbus-supply = <&battery_reg>;
+                nvidia,oc-pin = <0>;
+                status = "disabled";
+            };
+            usb2-1 {
+                mode = "host";
+                vbus-supply = <&battery_reg>;
+                nvidia,oc-pin = <1>;
+                status = "disabled";
+            };
+
+            usb2-2 {
+                mode = "host";
+                vbus-supply = <&battery_reg>;
+                nvidia,oc-pin = <2>;
+                status = "disabled";
+            };
+
+            usb3-0 {
+                nvidia,usb2-companion = <0>;
+                status = "disabled";
+            };
+            usb3-1 {
+                nvidia,usb2-companion = <1>;
+                status = "disabled";
+            };
+            usb3-2 {
+                nvidia,usb2-companion = <2>;
+                status = "disabled";
+            };
+        };
+    };
+    pinctrl@3520000 {
+        status = "okay";
+        pinctrl-0 = <&tegra_xusb_padctl_pinmux_default>;
+        pinctrl-1 = <&vbus_en0_sfio_tristate_state>;
+        pinctrl-2 = <&vbus_en1_sfio_tristate_state>;
+        pinctrl-3 = <&vbus_en0_sfio_passthrough_state>;
+        pinctrl-4 = <&vbus_en1_sfio_passthrough_state>;
+        pinctrl-5 = <&vbus_en0_default_state>;
+        pinctrl-6 = <&vbus_en1_default_state>;
+        pinctrl-names = "default",
+            "vbus_en0_sfio_tristate", "vbus_en1_sfio_tristate",
+            "vbus_en0_sfio_passthrough", "vbus_en1_sfio_passthrough",
+            "vbus_en0_default", "vbus_en1_default";
+        tegra_xusb_padctl_pinmux_default: pinmux {
+            /* Quill does not support usb3-micro AB */
+            usb2-port0 {
+                nvidia,lanes = "otg-0";
+                nvidia,function = "xusb";
+                nvidia,port-cap = <TEGRA_PADCTL_PORT_OTG_CAP>;
+                nvidia,oc-pin = <0>;
+                status = "disabled";
+            };
+            usb2-port1 {
+                nvidia,lanes = "otg-1";
+                nvidia,function = "xusb";
+                nvidia,port-cap = <TEGRA_PADCTL_PORT_HOST_ONLY>;
+                nvidia,oc-pin = <1>;
+                status = "disabled";
+            };
+
+            usb2-port2 {
+                nvidia,lanes = "otg-2";
+                nvidia,function = "xusb";
+                nvidia,port-cap = <TEGRA_PADCTL_PORT_HOST_ONLY>;
+                nvidia,oc-pin = <2>;
+                status = "disabled";
+            };
+
+            usb3-port0 {
+                nvidia,lanes = "usb3-0";
+                nvidia,port-cap = <TEGRA_PADCTL_PORT_HOST_ONLY>;
+                nvidia,oc-pin = <0>;
+                status = "disabled";
+            };
+
+            usb3-port1 {
+                nvidia,lanes = "usb3-1";
+                nvidia,port-cap = <TEGRA_PADCTL_PORT_HOST_ONLY>;
+                nvidia,oc-pin = <1>;
+                status = "disabled";
+            };
+
+            usb3-port2 {
+                nvidia,lanes = "usb3-2";
+                nvidia,port-cap = <TEGRA_PADCTL_PORT_HOST_ONLY>;
+                nvidia,oc-pin = <2>;
+                status = "disabled";
+            };
+        };
+    };
+    pcie-controller@10003000 {
+        pci@1,0 {
+            nvidia,num-lanes = <4>;
+            nvidia,disable-clock-request;
+            status = "disabled";
+        };
+        pci@2,0 {
+            nvidia,num-lanes = <0>;
+            status = "disabled";
+        };
+        pci@3,0 {
+            nvidia,num-lanes = <1>;
+            status = "disabled";
+        };
+    };
+
+};


### PR DESCRIPTION
The kernel sources were obtained in an email from CTI (they are hosted at http://connecttech.com/ftp/dropbox/cti-l4t-src-v125.tgz).

- I modified them slightly to use the directory structure of linux-tegra where the nvidia directory is inside the kernel directory,
and not the structure of nvidia/CTI where the nvidia directory is one level above the kernel directory.
- The baseline version used by CTI is slightly older than the version used by madisongh and does not compile with GCC 8, so I did not take all the files from CTI.

Signed-off-by: Etienne Cordonnier <etienne.cordonnier@taurob.com>